### PR TITLE
return empty JSON object instead of empty string

### DIFF
--- a/src/collectors/postfix/postfix.py
+++ b/src/collectors/postfix/postfix.py
@@ -78,12 +78,12 @@ class PostfixCollector(diamond.collector.Collector):
                     json_string += data
             except socket.error:
                 self.log.exception("Error talking to postfix-stats")
-                return ''
+                return '{}'
         finally:
             if s:
                 s.close()
 
-        return json_string
+        return json_string or '{}'
 
     def get_data(self):
         json_string = self.get_json()


### PR DESCRIPTION
`json.loads('')` fails, because the empty string is not valid JSON. I return an empty object from `get_json` instead

I don't know whether it's better to fix this here, or at https://github.com/python-diamond/Diamond/blob/8fa02fa4616c6ebedceaa64f8f7fe24d94d867ba/src/collectors/postfix/postfix.py#L89
