### PR TITLE
add a way to monitor multiple flume processes

### DIFF
--- a/src/collectors/flume/test/testflume.py
+++ b/src/collectors/flume/test/testflume.py
@@ -19,6 +19,13 @@ class TestFlumeCollector(CollectorTestCase):
 
         self.collector = FlumeCollector(config, None)
 
+        config = get_collector_config('FlumeCollector', {
+            'interval': 10,
+            'req_port': '19991,19992'
+        })
+
+        self.collector = FlumeCollector(config, None)
+
     def test_import(self):
         self.assertTrue(FlumeCollector)
 


### PR DESCRIPTION
This will add a way to monitor multiple flume processes per host. It also keeps the normal functionality of a single flume processes on a host. 

We run both setups where we have a single process and also 4 and this change passes the tests and also works in production. 