### PR TITLE
Adding CassandraJolokiaCollector for collecting latency percentile stats

### DIFF
--- a/src/collectors/jolokia/cassandra_jolokia.py
+++ b/src/collectors/jolokia/cassandra_jolokia.py
@@ -1,0 +1,98 @@
+# coding=utf-8
+
+"""
+Collects Cassandra JMX metrics from the Jolokia Agent.  Extends the JolokiaCollector to
+interpret Histogram beans with information about the distribution of request latencies.
+
+#### Example Configuration
+CassandraJolokiaCollector uses a regular expression to determine which attributes represent histograms.
+This regex can be overridden by providing a `histogram_regex` in your configuration.  You can also override
+`percentiles` to collect specific percentiles from the histogram statistics.  The format is shown below
+with the default values.
+
+CassandraJolokiaCollector.conf
+
+```
+    percentiles '50,95,99'
+    histogram_regex '.*HistogramMicros$'
+```
+"""
+
+from jolokia import JolokiaCollector
+import math
+import string
+import re
+
+
+class CassandraJolokiaCollector(JolokiaCollector):
+    # override to allow setting which percentiles will be collected
+    def get_default_config_help(self):
+        config_help = super(CassandraJolokiaCollector, self).get_default_config_help()
+        config_help.update({
+            'percentiles': 'Comma separated list of percentiles to be collected (e.g., "50,95,99").',
+            'histogram_regex': 'Filter to only process attributes that match this regex'
+        })
+        return config_help
+
+    # override to allow setting which percentiles will be collected
+    def get_default_config(self):
+        config = super(CassandraJolokiaCollector, self).get_default_config()
+        config.update({
+            'percentiles': '50,95,99',
+            'histogram_regex': '.*HistogramMicros$'
+        })
+        return config
+
+    def __init__(self, config, handlers):
+        super(CassandraJolokiaCollector, self).__init__(config, handlers)
+        self.offsets = self.create_offsets(91)
+        self.update_config(self.config)
+
+    def update_config(self, config):
+        if config.has_key('percentiles'):
+            self.percentiles = map(int, string.split(config['percentiles'], ','))
+        if config.has_key('histogram_regex'):
+            self.histogram_regex = re.compile(config['histogram_regex'])
+
+    # override: Interpret beans that match the `histogram_regex` as histograms, and collect
+    # percentiles from them.
+    def interpret_bean_with_list(self, prefix, values):
+        if not self.histogram_regex.match(prefix):
+            return
+
+        buckets = values
+        for percentile in self.percentiles:
+            percentile_value = self.compute_percentile(self.offsets, buckets, percentile)
+            self.publish("%s.p%s" % (prefix, percentile), percentile_value)
+
+    # Adapted from Cassandra docs: http://www.datastax.com/documentation/cassandra/2.0/cassandra/tools/toolsCFhisto.html
+    # The index corresponds to the x-axis in a histogram.  It represents buckets of values, which are
+    # a series of ranges. Each offset includes the range of values greater than the previous offset
+    # and less than or equal to the current offset. The offsets start at 1 and each subsequent offset
+    # is calculated by multiplying the previous offset by 1.2, rounding up, and removing duplicates. The
+    # offsets can range from 1 to approximately 25 million, with less precision as the offsets get larger.
+    def compute_percentile(self, offsets, buckets, percentile_int):
+        non_zero_points_sum = sum(buckets)
+        if non_zero_points_sum is 0:
+            return 0
+        middle_point_index = math.floor(non_zero_points_sum * (percentile_int / float(100)))
+
+        points_seen = 0
+        for index, bucket in enumerate(buckets):
+            points_seen += bucket
+            if points_seen >= middle_point_index:
+                return round((offsets[index] - offsets[index - 1]) / 2)
+
+    # Returns a list of offsets for `n` buckets.
+    def create_offsets(self, bucket_count):
+        last_num = 1
+        offsets = [last_num]
+
+        for index in range(bucket_count):
+            next_num = round(last_num * 1.2)
+            if next_num == last_num:
+                next_num += 1
+            offsets.append(next_num)
+            last_num = next_num
+
+        return offsets

--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -143,3 +143,10 @@ class JolokiaCollector(diamond.collector.Collector):
                 self.publish(key, v)
             elif type(v) in [dict]:
                 self.collect_bean("%s.%s" % (prefix, k), v)
+            elif type(v) in [list]:
+                self.interpret_bean_with_list("%s.%s" % (prefix, k), v)
+
+    # There's no unambiguous way to interpret list values, so
+    # this hook lets subclasses handle them.
+    def interpret_bean_with_list(self, prefix, values):
+        pass

--- a/src/collectors/jolokia/test/testcassandra_jolokia.py
+++ b/src/collectors/jolokia/test/testcassandra_jolokia.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import patch
+
+from diamond.collector import Collector
+
+from cassandra_jolokia import CassandraJolokiaCollector
+
+################################################################################
+
+
+class TestCassandraJolokiaCollector(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('CassandraJolokiaCollector', {})
+
+        self.collector = CassandraJolokiaCollector(config, None)
+
+    # Used for all the tests so the expected numbers are all the same.
+    def fixture_values_a(self):
+        return [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,3,1,1,8,5,6,1,6,5,3,8,9,10,7,8,7,5,5,5,3,3,2,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+
+    def empty_fixture_values(self):
+        return [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+
+    def expected_percentiles_for_fixture_a(self, percentile_key):
+        return {
+            'p25': 192.0,
+            'p50': 398.0,
+            'p75': 824.0,
+            'p95': 2050.0,
+            'p99': 2952.0
+        }[percentile_key]
+
+    def test_import(self):
+        self.assertTrue(CassandraJolokiaCollector)
+
+    def test_should_compute_percentiles_accurately(self):
+        ninety_offsets = self.collector.create_offsets(90)
+        percentile_value = self.collector.compute_percentile(ninety_offsets, self.fixture_values_a(), 50)
+        self.assertEqual(percentile_value, 398.0)
+
+    def test_should_compute_percentiles_accurately_when_empty(self):
+        ninety_offsets = self.collector.create_offsets(90)
+        self.assertEqual(self.collector.compute_percentile(ninety_offsets, self.empty_fixture_values(), 50), 0.0)
+        self.assertEqual(self.collector.compute_percentile(ninety_offsets, self.empty_fixture_values(), 95), 0.0)
+        self.assertEqual(self.collector.compute_percentile(ninety_offsets, self.empty_fixture_values(), 99), 0.0)
+
+    @patch.object(Collector, 'publish')
+    def test_should_not_collect_non_histogram_attributes(self, publish_mock):
+        self.collector.interpret_bean_with_list('RecentReadLatencyMicros', self.fixture_values_a())
+        self.assertPublishedMany(publish_mock, {})
+
+    @patch.object(Collector, 'publish')
+    def test_should_collect_metrics_histogram_attributes(self, publish_mock):
+        self.collector.interpret_bean_with_list('RecentReadLatencyHistogramMicros', self.fixture_values_a())
+        self.assertPublishedMany(publish_mock, {
+            'RecentReadLatencyHistogramMicros.p50': self.expected_percentiles_for_fixture_a('p50'),
+            'RecentReadLatencyHistogramMicros.p95': self.expected_percentiles_for_fixture_a('p95'),
+            'RecentReadLatencyHistogramMicros.p99': self.expected_percentiles_for_fixture_a('p99')
+        })
+
+    @patch.object(Collector, 'publish')
+    def test_should_respect_percentiles_config(self, publish_mock):
+        self.collector.update_config({
+            'percentiles': '25,75'
+        })
+        self.collector.interpret_bean_with_list('RecentReadLatencyHistogramMicros', self.fixture_values_a())
+        self.assertPublishedMany(publish_mock, {
+            'RecentReadLatencyHistogramMicros.p25': self.expected_percentiles_for_fixture_a('p25'),
+            'RecentReadLatencyHistogramMicros.p75': self.expected_percentiles_for_fixture_a('p75'),
+        })
+
+    @patch.object(Collector, 'publish')
+    def test_should_respect_histogram_regex_config(self, publish_mock):
+        self.collector.update_config({
+            'histogram_regex': '^WackyMetric'
+        })
+        self.collector.interpret_bean_with_list('WackyMetricSeventeen', self.fixture_values_a())
+        self.assertPublishedMany(publish_mock, {
+            'WackyMetricSeventeen.p50': self.expected_percentiles_for_fixture_a('p50'),
+            'WackyMetricSeventeen.p95': self.expected_percentiles_for_fixture_a('p95'),
+            'WackyMetricSeventeen.p99': self.expected_percentiles_for_fixture_a('p99')
+        })
+
+################################################################################
+if __name__ == "__main__":
+    unittest.main()

--- a/src/collectors/jolokia/test/testjolokia.py
+++ b/src/collectors/jolokia/test/testjolokia.py
@@ -76,6 +76,19 @@ class TestJolokiaCollector(CollectorTestCase):
                            defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
+
+    @patch.object(Collector, 'publish')
+    @patch.object(JolokiaCollector, 'interpret_bean_with_list')
+    def test_should_allow_interpretation_of_list_values(self, interpret_bean_with_list_mock, publish_mock):
+        self.collector.collect_bean('prefix', {
+            'RecentWriteLatencyMicros': 100,
+            'RecentReadLatencyHistogramMicros': [1,2,3]
+        })
+        self.assertPublishedMany(publish_mock, {
+            'prefix.RecentWriteLatencyMicros': 100
+        })
+        interpret_bean_with_list_mock.assert_called_with('prefix.RecentReadLatencyHistogramMicros', [1, 2, 3])
+
     def get_metrics(self):
         prefix = 'java.lang.name_ParNew.type_GarbageCollector.LastGcInfo'
         return {


### PR DESCRIPTION
This adds a new hook to the `JolokiaCollector` for interpreting values that are lists, and a `CassandraJolokiaCollector` that takes advantage of the hook to collect percentiles of latency metrics that Cassandra is writing to JMX.  It's not clear how to collect beans with list of values, so the hook lets others subclass and interpret as needed, as is done here.

The format that Cassandra writes these in JMX is counts within different bucket sizes (http://www.datastax.com/documentation/cassandra/2.0/cassandra/tools/toolsCFhisto.html), and this is the basis for how this PR translates them to percentiles (org.apache.cassandra.utils.EstimatedHistogram.percentile inhttp://docs.webingenia.com/cassandra/doxygen/classorg_1_1apache_1_1cassandra_1_1utils_1_1EstimatedHistogram.html).

@kormoc Let me know if you have any other questions or feedback on how to make this better!
