### PR TITLE
Fix missing import in src/diamond/utils/log.py

### DIFF
--- a/src/diamond/utils/log.py
+++ b/src/diamond/utils/log.py
@@ -2,6 +2,7 @@
 
 
 import logging
+import logging.config
 import sys
 import os
 


### PR DESCRIPTION
Commit fixes missing import in src/diamond/utils/log.py as hinted in
https://github.com/BrightcoveOS/Diamond/issues/697
