### PR TITLE
Fix rpm make target to work with mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ rpm: buildrpm
 
 buildrpm: sdist
 	./setup.py bdist_rpm \
-		--release=`ls dist/*.noarch.rpm | wc -l`
+		--release=`ls dist/*.noarch.rpm | wc -l` \
+		--build-requires='python' \
+		--requires='python'
 
 deb: builddeb
 


### PR DESCRIPTION
explicitly add requirement for python so resulting SRPM can be built with mock
