### PR TITLE
postgres: split locks by type

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -214,6 +214,7 @@ class QueryStats(object):
                             'datname', self.dbname)),
                         'schemaname': row.get('schemaname', None),
                         'relname': row.get('relname', None),
+                        'locktype': row.get('locktype', None),
                         'indexrelname': row.get('indexrelname', None),
                         'metric': key,
                         'value': value,
@@ -390,10 +391,11 @@ class ConnectionStateStats(QueryStats):
 
 
 class LockStats(QueryStats):
-    path = "%(datname)s.locks.%(metric)s"
+    path = "%(datname)s.locks.%(locktype).%(metric)s"
     multi_db = False
     query = """
-        SELECT lower(mode) AS key,
+        SELECT lower(locktype),
+               lower(mode) AS key,
                count(*) AS value
         FROM pg_locks
         WHERE database IS NOT NULL


### PR DESCRIPTION
A table lock is probably more problematic than a row lock, so lets
not lump them together.

Note: this is currently not even tested. Just putting it here as a request for comment. I think this would be a good idea personally as currently you can't really get much useful info out of the lock stats) but as it is would break compatibility. Any comments @kormoc or @mattrobenolt ?
