### PR TITLE
Fix bug with parsing percentiles config in Cassandra Jolokia collector

### DIFF
--- a/src/collectors/jolokia/cassandra_jolokia.py
+++ b/src/collectors/jolokia/cassandra_jolokia.py
@@ -44,7 +44,7 @@ class CassandraJolokiaCollector(JolokiaCollector):
     def get_default_config(self):
         config = super(CassandraJolokiaCollector, self).get_default_config()
         config.update({
-            'percentiles': '50,95,99',
+            'percentiles': ['50', '95', '99'],
             'histogram_regex': '.*HistogramMicros$'
         })
         return config
@@ -56,8 +56,7 @@ class CassandraJolokiaCollector(JolokiaCollector):
 
     def update_config(self, config):
         if 'percentiles' in config:
-            self.percentiles = map(int, string.split(config['percentiles'],
-                                                     ','))
+            self.percentiles = map(int, config['percentiles'])
         if 'histogram_regex' in config:
             self.histogram_regex = re.compile(config['histogram_regex'])
 

--- a/src/collectors/jolokia/test/testcassandra_jolokia.py
+++ b/src/collectors/jolokia/test/testcassandra_jolokia.py
@@ -79,7 +79,7 @@ class TestCassandraJolokiaCollector(CollectorTestCase):
     @patch.object(Collector, 'publish')
     def test_should_respect_percentiles_config(self, publish_mock):
         self.collector.update_config({
-            'percentiles': '25,75'
+            'percentiles': ['25', '75']
         })
         self.collector.interpret_bean_with_list(
             'RecentReadLatencyHistogramMicros', self.fixture_values_a())


### PR DESCRIPTION
This fixes a bug with parsing `percentiles` passed through the config file.  `configobj` will parse comma-separated lists already, so no need to do that in the collector code.

cc @kormoc @MichaelDoyle 