### PR TITLE
HttpJson collector: Allow usage of header configuration

### DIFF
--- a/src/collectors/httpjson/httpjson.py
+++ b/src/collectors/httpjson/httpjson.py
@@ -20,7 +20,8 @@ class HTTPJSONCollector(diamond.collector.Collector):
         config_help = super(HTTPJSONCollector, self).get_default_config_help()
         config_help.update({
             'url': 'Full URL',
-            'headers': 'Header variable if needed. Will be added to every request',
+            'headers': 'Header variable if needed. '
+                'Will be added to every request',
         })
         return config_help
 

--- a/src/collectors/httpjson/httpjson.py
+++ b/src/collectors/httpjson/httpjson.py
@@ -19,7 +19,7 @@ class HTTPJSONCollector(diamond.collector.Collector):
     def get_default_config_help(self):
         config_help = super(HTTPJSONCollector, self).get_default_config_help()
         config_help.update({
-            'url': 'Full URL'
+            'url': 'Full URL',
             'headers': 'Header variable if needed. Will be added to every request',
         })
         return config_help

--- a/src/collectors/httpjson/httpjson.py
+++ b/src/collectors/httpjson/httpjson.py
@@ -21,7 +21,7 @@ class HTTPJSONCollector(diamond.collector.Collector):
         config_help.update({
             'url': 'Full URL',
             'headers': 'Header variable if needed. '
-                'Will be added to every request',
+            'Will be added to every request',
         })
         return config_help
 

--- a/src/collectors/httpjson/httpjson.py
+++ b/src/collectors/httpjson/httpjson.py
@@ -20,6 +20,7 @@ class HTTPJSONCollector(diamond.collector.Collector):
         config_help = super(HTTPJSONCollector, self).get_default_config_help()
         config_help.update({
             'url': 'Full URL'
+            'headers': 'Header variable if needed. Will be added to every request',
         })
         return config_help
 
@@ -27,7 +28,8 @@ class HTTPJSONCollector(diamond.collector.Collector):
         default_config = super(HTTPJSONCollector, self).get_default_config()
         default_config.update({
             'path': 'httpjson',
-            'url': 'http://localhost/stat'
+            'url': 'http://localhost/stat',
+            'headers': {'User-Agent': 'Diamond HTTP collector'},
         })
         return default_config
 
@@ -48,7 +50,7 @@ class HTTPJSONCollector(diamond.collector.Collector):
     def collect(self):
         url = self.config['url']
 
-        req = urllib2.Request(url)
+        req = urllib2.Request(url, headers=self.config['headers'])
         req.add_header('Content-type', 'application/json')
 
         try:


### PR DESCRIPTION
I wanted to be able to specify some headers on my httpjson collector,
as in the http one ...here is my small patch about it ..

It's useful for authorisation, for Host check, and plenty other things
