### PR TITLE
Fix bug with not escaping metric keys when reading Cassandra latency histograms from Jolokia

### DIFF
--- a/src/collectors/jolokia/cassandra_jolokia.py
+++ b/src/collectors/jolokia/cassandra_jolokia.py
@@ -68,10 +68,11 @@ class CassandraJolokiaCollector(JolokiaCollector):
             return
 
         buckets = values
+        offsets = self.offsets
         for percentile in self.percentiles:
-            percentile_value = self.compute_percentile(
-                self.offsets, buckets, percentile)
-            self.publish("%s.p%s" % (prefix, percentile), percentile_value)
+            value = self.compute_percentile(offsets, buckets, percentile)
+            cleaned_key = self.clean_up("%s.p%s" % (prefix, percentile))
+            self.publish(cleaned_key, value)
 
     # Adapted from Cassandra docs:
     # https://bit.ly/13M5JPE

--- a/src/collectors/jolokia/test/testcassandra_jolokia.py
+++ b/src/collectors/jolokia/test/testcassandra_jolokia.py
@@ -21,7 +21,7 @@ class TestCassandraJolokiaCollector(CollectorTestCase):
         self.collector = CassandraJolokiaCollector(config, None)
 
     # Used for all the tests so the expected numbers are all the same.
-    def fixture_values_a(self):
+    def fixture_a(self):
         values = [0]*92
         values[30:56] = [3, 3, 1, 1, 8, 5, 6, 1, 6, 5, 3, 8, 9, 10, 7, 8, 7, 5,
                          5, 5, 3, 3, 2, 2, 2]
@@ -30,7 +30,7 @@ class TestCassandraJolokiaCollector(CollectorTestCase):
     def empty_fixture_values(self):
         return [0]*91
 
-    def expected_percentiles_for_fixture_a(self, percentile_key):
+    def expected_fixture_a_p(self, percentile_key):
         return {
             'p25': 192.0,
             'p50': 398.0,
@@ -45,7 +45,7 @@ class TestCassandraJolokiaCollector(CollectorTestCase):
     def test_should_compute_percentiles_accurately(self):
         ninety_offsets = self.collector.create_offsets(90)
         percentile_value = self.collector.compute_percentile(
-            ninety_offsets, self.fixture_values_a(), 50)
+            ninety_offsets, self.fixture_a(), 50)
         self.assertEqual(percentile_value, 398.0)
 
     def test_should_compute_percentiles_accurately_when_empty(self):
@@ -60,20 +60,42 @@ class TestCassandraJolokiaCollector(CollectorTestCase):
     @patch.object(Collector, 'publish')
     def test_should_not_collect_non_histogram_attributes(self, publish_mock):
         self.collector.interpret_bean_with_list(
-            'RecentReadLatencyMicros', self.fixture_values_a())
+            'RecentReadLatencyMicros', self.fixture_a())
         self.assertPublishedMany(publish_mock, {})
 
     @patch.object(Collector, 'publish')
     def test_should_collect_metrics_histogram_attributes(self, publish_mock):
         self.collector.interpret_bean_with_list(
-            'RecentReadLatencyHistogramMicros', self.fixture_values_a())
+            'RecentReadLatencyHistogramMicros', self.fixture_a())
         self.assertPublishedMany(publish_mock, {
             'RecentReadLatencyHistogramMicros.p50':
-            self.expected_percentiles_for_fixture_a('p50'),
+            self.expected_fixture_a_p('p50'),
             'RecentReadLatencyHistogramMicros.p95':
-            self.expected_percentiles_for_fixture_a('p95'),
+            self.expected_fixture_a_p('p95'),
             'RecentReadLatencyHistogramMicros.p99':
-            self.expected_percentiles_for_fixture_a('p99')
+            self.expected_fixture_a_p('p99')
+        })
+
+    @patch.object(Collector, 'publish')
+    # db:columnfamily=HintsColumnFamily,keyspace=system,type=ColumnFamilies:
+    def test_should_escape_histogram_attributes(self, publish_mock):
+        test_bean = ','.join([
+            'db:columnfamily=HintsColumnFamily',
+            'keyspace=system',
+            'type=ColumnFamilies:RecentReadLatencyHistogramMicros'
+        ])
+        self.collector.interpret_bean_with_list(test_bean, self.fixture_a())
+
+        expected_base = '.'.join([
+            'db.columnfamily_HintsColumnFamily',
+            'keyspace_system',
+            'type_ColumnFamilies',
+            'RecentReadLatencyHistogramMicros'
+        ])
+        self.assertPublishedMany(publish_mock, {
+            '.'.join([expected_base, 'p50']): self.expected_fixture_a_p('p50'),
+            '.'.join([expected_base, 'p95']): self.expected_fixture_a_p('p95'),
+            '.'.join([expected_base, 'p99']): self.expected_fixture_a_p('p99')
         })
 
     @patch.object(Collector, 'publish')
@@ -82,12 +104,12 @@ class TestCassandraJolokiaCollector(CollectorTestCase):
             'percentiles': '25,75'
         })
         self.collector.interpret_bean_with_list(
-            'RecentReadLatencyHistogramMicros', self.fixture_values_a())
+            'RecentReadLatencyHistogramMicros', self.fixture_a())
         self.assertPublishedMany(publish_mock, {
             'RecentReadLatencyHistogramMicros.p25':
-            self.expected_percentiles_for_fixture_a('p25'),
+            self.expected_fixture_a_p('p25'),
             'RecentReadLatencyHistogramMicros.p75':
-            self.expected_percentiles_for_fixture_a('p75'),
+            self.expected_fixture_a_p('p75'),
         })
 
     @patch.object(Collector, 'publish')
@@ -96,14 +118,14 @@ class TestCassandraJolokiaCollector(CollectorTestCase):
             'histogram_regex': '^WackyMetric'
         })
         self.collector.interpret_bean_with_list(
-            'WackyMetricSeventeen', self.fixture_values_a())
+            'WackyMetricSeventeen', self.fixture_a())
         self.assertPublishedMany(publish_mock, {
             'WackyMetricSeventeen.p50':
-            self.expected_percentiles_for_fixture_a('p50'),
+            self.expected_fixture_a_p('p50'),
             'WackyMetricSeventeen.p95':
-            self.expected_percentiles_for_fixture_a('p95'),
+            self.expected_fixture_a_p('p95'),
             'WackyMetricSeventeen.p99':
-            self.expected_percentiles_for_fixture_a('p99')
+            self.expected_fixture_a_p('p99')
         })
 
 ################################################################################


### PR DESCRIPTION
This fixes an escaping bug from https://github.com/python-diamond/Diamond/pull/21.  @kormoc apologies for missing this the first time around.