### PR TITLE
allow to config whether to propagate log of ArchiveHandler to its parent...

### DIFF
--- a/src/diamond/handler/archive.py
+++ b/src/diamond/handler/archive.py
@@ -24,6 +24,7 @@ class ArchiveHandler(Handler):
         # Create Archive Logger
         self.archive = logging.getLogger('archive')
         self.archive.setLevel(logging.DEBUG)
+        self.archive.propagate = self.config['propagate']
         # Create Archive Log Formatter
         formatter = logging.Formatter('%(message)s')
         # Create Archive Log Handler
@@ -48,6 +49,7 @@ class ArchiveHandler(Handler):
             'log_file': 'Path to the logfile',
             'days': 'How many days to store',
             'encoding': '',
+            'propagate': 'Pass handled metrics to configured root logger',
         })
 
         return config
@@ -62,6 +64,7 @@ class ArchiveHandler(Handler):
             'log_file': '',
             'days': 7,
             'encoding': None,
+            'propagate': False,
         })
 
         return config


### PR DESCRIPTION
... logger

ArchiveHandler is implemented by utilizing logging module, though it is not
considered as a logger. As a handler, it should not log the metrics that
it handles (same as all other handlers do).
This change turns off logging by default and
adds ability to turn that on through its configuration.