### PR TITLE
Graphite handler tunning

### DIFF
--- a/conf/diamond.conf.example
+++ b/conf/diamond.conf.example
@@ -54,7 +54,7 @@ days = 7
 ### Options for GraphiteHandler
 
 # Graphite server host
-host = graphite
+host = 127.0.0.1
 
 # Port to send metrics to
 port = 2003
@@ -69,7 +69,7 @@ batch = 1
 ### Options for GraphitePickleHandler
 
 # Graphite server host
-host = graphite
+host = 127.0.0.1
 
 # Port to send metrics to
 port = 2004

--- a/conf/diamond.conf.example.windows
+++ b/conf/diamond.conf.example.windows
@@ -55,7 +55,7 @@ days = 7
 ### Options for GraphiteHandler
 
 # Graphite server host
-host = graphite
+host = 127.0.0.1
 
 # Port to send metrics to
 port = 2003
@@ -70,7 +70,7 @@ batch = 1
 ### Options for GraphitePickleHandler
 
 # Graphite server host
-host = graphite
+host = 127.0.0.1
 
 # Port to send metrics to
 port = 2004

--- a/src/diamond/handler/graphitepickle.py
+++ b/src/diamond/handler/graphitepickle.py
@@ -65,6 +65,7 @@ class GraphitePickleHandler(GraphiteHandler):
         config = super(GraphitePickleHandler, self).get_default_config()
 
         config.update({
+            'port': 2004,
         })
 
         return config


### PR DESCRIPTION
- Set the default pickle port as 2004
- Use 127.0.0.1 instead of 'graphite' in example config