### PR TITLE
Add more verbose output when a collector fails for some reason

### DIFF
--- a/src/diamond/utils/scheduler.py
+++ b/src/diamond/utils/scheduler.py
@@ -83,7 +83,7 @@ def collector_process(collector, metric_queue, log):
             reload_config = True
             pass
 
-        except:
+        except Exception:
             log.exception('Collector failed!')
             break
 

--- a/src/diamond/utils/scheduler.py
+++ b/src/diamond/utils/scheduler.py
@@ -83,6 +83,10 @@ def collector_process(collector, metric_queue, log):
             reload_config = True
             pass
 
+        except:
+            log.exception('Collector failed!')
+            break
+
 
 def handler_process(handlers, metric_queue, log):
     proc = multiprocessing.current_process()


### PR DESCRIPTION
I noticed that if a collector fails for some reason (i.e. an unchecked exception) no information is written to the logs about the failure. This would make diagnosing problems difficult, so I've added a bare except to log the failure.