### PR TITLE
updated default_info_keys to reflect change in psutil 2.0

### DIFF
--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -152,6 +152,7 @@ class ProcessResourcesCollector(diamond.collector.Collector):
         'num_fds',
         'memory_percent',
         'ext_memory_info',
+        'memory_info_ex',
     ]
 
     def save_process_info(self, pg_name, process_info):


### PR DESCRIPTION
according to http://grodola.blogspot.com/2014/01/psutil-20-porting.html psutil does not report ext_memory_info starting at version 2.0. Instead, use memory_info_ex.
Adding them both to the default_info_keys ensure memory values will be reported whatever version is used (even if the metrics name changes)
