### PR TITLE
RabbitMQ: collect overall message metrics

### DIFF
--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -87,8 +87,10 @@ class RabbitMQCollector(diamond.collector.Collector):
             httpclient = pyrabbit.http.HTTPClient(self.config['host'],
                                                   self.config['user'],
                                                   self.config['password'])
-            node_name = httpclient.do_call('overview', 'GET')['node']
-            node_data = httpclient.do_call('nodes/{0}'.format(node_name), 'GET')
+            overview = httpclient.do_call('overview', 'GET')
+            for metric in ['messages', 'messages_ready', 'messages_unacknowledged']:
+                self.publish('health.{0}'.format(metric), overview['queue_totals'][metric])
+            node_data = httpclient.do_call('nodes/{0}'.format(overview['node']), 'GET')
             for metric in health_metrics:
                 self.publish('health.{0}'.format(metric), node_data[metric])
             if self.config['cluster']:

--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -83,14 +83,23 @@ class RabbitMQCollector(diamond.collector.Collector):
             'proc_used',
             'proc_total',
             ]
+
+        queue_total_metrics = [
+            'messages',
+            'messages_ready',
+            'messages_unacknowledged'
+        ]
+
         try:
             httpclient = pyrabbit.http.HTTPClient(self.config['host'],
                                                   self.config['user'],
                                                   self.config['password'])
             overview = httpclient.do_call('overview', 'GET')
-            for metric in ['messages', 'messages_ready', 'messages_unacknowledged']:
-                self.publish('health.{0}'.format(metric), overview['queue_totals'][metric])
-            node_data = httpclient.do_call('nodes/{0}'.format(overview['node']), 'GET')
+            for metric in queue_total_metrics:
+                self.publish('health.{0}'.format(metric),
+                             overview['queue_totals'][metric])
+            node_data = httpclient.do_call('nodes/{0}'.format(overview['node']),
+                                           'GET')
             for metric in health_metrics:
                 self.publish('health.{0}'.format(metric), node_data[metric])
             if self.config['cluster']:


### PR DESCRIPTION
This adds health.[messages|messages_ready|messages_unacknowledged] metrics to the RabbitMQ collector, for monitoring the total number of messages in RabbitMQ.

If you have lots of RabbitMQ queues then pushing per-queue metrics and then summing them isn't ideal.