### PR TITLE
Handle sensors with no value

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -18,3 +18,4 @@ redis
 simplejson
 setproctitle
 psycopg2
+PySensors

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ python:
 
 # command to install dependencies, e.g. pip install -r requirements.txt
 install:
+    - apt-get update -qq
+    - apt-get install -y libsensors4-dev
     - pip install -r .travis.requirements.txt
     - pip install pep8==1.4.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ python:
 
 # command to install dependencies, e.g. pip install -r requirements.txt
 install:
-    - apt-get update -qq
-    - apt-get install -y libsensors4-dev
+    - sudo apt-get update -qq
+    - sudo apt-get install -y libsensors4-dev
     - pip install -r .travis.requirements.txt
     - pip install pep8==1.4.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ python:
 
 # command to install dependencies, e.g. pip install -r requirements.txt
 install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y libsensors4-dev
     - pip install -r .travis.requirements.txt
     - pip install pep8==1.4.6
 
@@ -25,3 +23,7 @@ notifications:
         - kormoc@gmail.com
     on_success: change
     on_failure: always
+
+addons:
+    apt_packages:
+    - libsensors4

--- a/src/collectors/lmsensors/lmsensors.py
+++ b/src/collectors/lmsensors/lmsensors.py
@@ -58,7 +58,7 @@ class LMSensorsCollector(diamond.collector.Collector):
                     label = feature.label.replace(' ', '-')
                     try:
                         value = feature.get_value()
-                    except:
+                    except Exception:
                         if self.config['send_zero']:
                             value = 0
 

--- a/src/collectors/lmsensors/lmsensors.py
+++ b/src/collectors/lmsensors/lmsensors.py
@@ -31,7 +31,6 @@ class LMSensorsCollector(diamond.collector.Collector):
     def get_default_config_help(self):
         config_help = super(LMSensorsCollector, self).get_default_config_help()
         config_help.update({
-            'fahrenheit': "True/False",
             'send_zero': 'Send sensor data even when there is no value'
         })
         return config_help
@@ -43,7 +42,6 @@ class LMSensorsCollector(diamond.collector.Collector):
         config = super(LMSensorsCollector, self).get_default_config()
         config.update({
             'path': 'sensors',
-            'fahrenheit': 'True',
             'send_zero': 'False'
         })
         return config

--- a/src/collectors/lmsensors/lmsensors.py
+++ b/src/collectors/lmsensors/lmsensors.py
@@ -5,11 +5,11 @@ This class collects data from libsensors. It should work against libsensors 2.x
 and 3.x, pending support within the PySensors Ctypes binding:
 [http://pypi.python.org/pypi/PySensors/](http://pypi.python.org/pypi/PySensors/)
 
-Requires: 'sensors' to be installed, configured, and the relevant kernel modules
-to be loaded. Requires: PySensors requires Python 2.6+
+Requires: 'sensors' to be installed, configured, and the relevant kernel
+modules to be loaded. Requires: PySensors requires Python 2.6+
 
-If you're having issues, check your version of 'sensors'. This collector written
-against: sensors version 3.1.2 with libsensors version 3.1.2
+If you're having issues, check your version of 'sensors'. This collector
+written against: sensors version 3.1.2 with libsensors version 3.1.2
 
 #### Dependencies
 
@@ -21,6 +21,7 @@ import diamond.collector
 
 try:
     import sensors
+    sensors  # workaround for pyflakes issue #13
 except ImportError:
     sensors = None
 
@@ -31,6 +32,7 @@ class LMSensorsCollector(diamond.collector.Collector):
         config_help = super(LMSensorsCollector, self).get_default_config_help()
         config_help.update({
             'fahrenheit': "True/False",
+            'send_zero': 'Send sensor data even when there is no value'
         })
         return config_help
 
@@ -41,7 +43,8 @@ class LMSensorsCollector(diamond.collector.Collector):
         config = super(LMSensorsCollector, self).get_default_config()
         config.update({
             'path': 'sensors',
-            'fahrenheit': 'True'
+            'fahrenheit': 'True',
+            'send_zero': 'False'
         })
         return config
 
@@ -54,8 +57,14 @@ class LMSensorsCollector(diamond.collector.Collector):
         try:
             for chip in sensors.iter_detected_chips():
                 for feature in chip:
-                    self.publish(".".join([str(chip),
-                                           feature.label.replace(' ', '-')]),
-                                 feature.get_value())
+                    label = feature.label.replace(' ', '-')
+                    try:
+                        value = feature.get_value()
+                    except:
+                        if self.config['send_zero']:
+                            value = 0
+
+                    if value is not None:
+                        self.publish(".".join([str(chip), label]), value)
         finally:
             sensors.cleanup()

--- a/src/collectors/lmsensors/lmsensors.py
+++ b/src/collectors/lmsensors/lmsensors.py
@@ -42,7 +42,7 @@ class LMSensorsCollector(diamond.collector.Collector):
         config = super(LMSensorsCollector, self).get_default_config()
         config.update({
             'path': 'sensors',
-            'send_zero': 'False'
+            'send_zero': False
         })
         return config
 
@@ -56,6 +56,7 @@ class LMSensorsCollector(diamond.collector.Collector):
             for chip in sensors.iter_detected_chips():
                 for feature in chip:
                     label = feature.label.replace(' ', '-')
+                    value = None
                     try:
                         value = feature.get_value()
                     except Exception:

--- a/src/collectors/lmsensors/test/testlmsensors.py
+++ b/src/collectors/lmsensors/test/testlmsensors.py
@@ -1,22 +1,79 @@
 #!/usr/bin/python
 # coding=utf-8
-################################################################################
+###############################################################################
 
 from test import CollectorTestCase
 from test import get_collector_config
+from mock import patch
 
+from diamond.collector import Collector
 from lmsensors import LMSensorsCollector
 
 
+class FeatureMock:
+    def __init__(self, label, value=None):
+        self.label = label
+        self.value = value
+
+    def get_value(self):
+        if self.value is not None:
+            return self.value
+
+        raise Exception("Value not present")
+
+
+class ChipMock:
+    def __init__(self, label, features):
+        self.label = label
+        self.features = features
+
+    def __iter__(self):
+        for feature in self.features:
+            yield feature
+
+    def __str__(self):
+        return self.label
+
+
 class TestLMSensorsCollector(CollectorTestCase):
-    def setUp(self, allowed_names=None):
-        if not allowed_names:
-            allowed_names = []
-        config = get_collector_config('LMSensorsCollector', {
-            'allowed_names': allowed_names,
-            'interval': 1
-        })
+    def setUp(self):
+        config = get_collector_config('LMSensorsCollector', {})
         self.collector = LMSensorsCollector(config, None)
 
     def test_import(self):
         self.assertTrue(LMSensorsCollector)
+
+    @patch.object(Collector, 'publish')
+    def test_simple_sensor(self, publish_mock):
+        feature = FeatureMock('Core 0', 10)
+        chip = ChipMock("coretemp-isa-0000", [feature])
+        patch_detected_chips_iter = patch('sensors.iter_detected_chips',
+                                          return_value=[chip])
+        patch_detected_chips_iter.start()
+        self.collector.collect()
+        patch_detected_chips_iter.stop()
+        self.assertPublished(publish_mock, 'coretemp-isa-0000.Core-0', 10)
+
+    @patch.object(Collector, 'publish')
+    def test_empty_sensor(self, publish_mock):
+        feature = FeatureMock('Core 0')
+        chip = ChipMock('coretemp-isa-0000', [feature])
+        patch_detected_chips_iter = patch('sensors.iter_detected_chips',
+                                          return_value=[chip])
+        patch_detected_chips_iter.start()
+        self.collector.collect()
+        patch_detected_chips_iter.stop()
+        self.assertUnpublished(publish_mock, 'coretemp-isa-0000.Core-0', None)
+
+    @patch.object(Collector, 'publish')
+    def test_empty_zero_sensor(self, publish_mock):
+        self.collector.config['send_zero'] = True
+
+        feature = FeatureMock('Core 0')
+        chip = ChipMock('coretemp-isa-0000', [feature])
+        patch_detected_chips_iter = patch('sensors.iter_detected_chips',
+                                          return_value=[chip])
+        patch_detected_chips_iter.start()
+        self.collector.collect()
+        patch_detected_chips_iter.stop()
+        self.assertPublished(publish_mock, 'coretemp-isa-0000.Core-0', 0)


### PR DESCRIPTION
Certain VM environments have sensors declared with no value. Thus the sensor collector need to support iterating through these values safely by catching exceptions and publishing 0 if desired.

Also removed unused 'fahrenheit' config option