### PR TITLE
Fixes re-building of SRPM with mock

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ provides = diamond
 post-install = rpm/postinstall
 pre-install = rpm/preuninstall
 install-script = rpm/install
+build_requires = python-setuptools


### PR DESCRIPTION
The SRPM generated by setuptools does not rebuild under mock (complains about not being able to find python).

This change fixes that.