### PR TITLE
Redis connections via unix sockets

### DIFF
--- a/src/collectors/redisstat/redisstat.py
+++ b/src/collectors/redisstat/redisstat.py
@@ -137,8 +137,12 @@ class RedisCollector(diamond.collector.Collector):
                 auth = port_auth.partition('/')[2] or None
 
                 if nickname is None:
-                    nickname = os.path.splitext(os.path.basename(unix_socket))[0]
-                self.instances[nickname] = (self._DEFAULT_HOST, self._DEFAULT_PORT, unix_socket, auth)
+                    nickname = os.path.splitext(
+                        os.path.basename(unix_socket))[0]
+                self.instances[nickname] = (self._DEFAULT_HOST,
+                                            self._DEFAULT_PORT,
+                                            unix_socket,
+                                            auth)
             else:
                 if '/' in hostport:
                     parts = hostport.split('/')

--- a/src/collectors/redisstat/redisstat.py
+++ b/src/collectors/redisstat/redisstat.py
@@ -39,11 +39,16 @@ If not specified the port will be used.
 
 import diamond.collector
 import time
+import os
 
 try:
     import redis
 except ImportError:
     redis = None
+
+
+SOCKET_PREFIX = 'unix:'
+SOCKET_PREFIX_LEN = len(SOCKET_PREFIX)
 
 
 class RedisCollector(diamond.collector.Collector):
@@ -106,29 +111,40 @@ class RedisCollector(diamond.collector.Collector):
                 nickname = None
                 hostport = instance
 
-            if '/' in hostport:
-                parts = hostport.split('/')
-                hostport = parts[0]
-                auth = parts[1]
-            else:
-                auth = None
+            if hostport.startswith(SOCKET_PREFIX):
+                unix_socket, __, port_auth = hostport[
+                    SOCKET_PREFIX_LEN:].partition(':')
+                auth = port_auth.partition('/')[2] or None
 
-            if ':' in hostport:
-                if hostport[0] == ':':
-                    host = self._DEFAULT_HOST
-                    port = int(hostport[1:])
+                if nickname is None:
+                    nickname = os.path.basename(unix_socket)
+                self.instances[nickname] = (self._DEFAULT_HOST, self._DEFAULT_PORT, unix_socket, auth)
+            else:
+                if '/' in hostport:
+                    parts = hostport.split('/')
+                    hostport = parts[0]
+                    auth = parts[1]
                 else:
-                    parts = hostport.split(':')
-                    host = parts[0]
-                    port = int(parts[1])
-            else:
-                host = hostport
-                port = self._DEFAULT_PORT
+                    auth = None
 
-            if nickname is None:
-                nickname = str(port)
+                if ':' in hostport:
+                    if hostport[0] == ':':
+                        host = self._DEFAULT_HOST
+                        port = int(hostport[1:])
+                    else:
+                        parts = hostport.split(':')
+                        host = parts[0]
+                        port = int(parts[1])
+                else:
+                    host = hostport
+                    port = self._DEFAULT_PORT
 
-            self.instances[nickname] = (host, port, auth)
+                if nickname is None:
+                    nickname = str(port)
+
+                self.instances[nickname] = (host, port, None, auth)
+
+        self.log.debug("Configured instances: %s" % self.instances.items())
 
     def get_default_config_help(self):
         config_help = super(RedisCollector, self).get_default_config_help()
@@ -164,7 +180,7 @@ class RedisCollector(diamond.collector.Collector):
         })
         return config
 
-    def _client(self, host, port, auth):
+    def _client(self, host, port, unix_socket, auth):
         """Return a redis client for the configuration.
 
 :param str host: redis host
@@ -176,12 +192,13 @@ class RedisCollector(diamond.collector.Collector):
         timeout = int(self.config['timeout'])
         try:
             cli = redis.Redis(host=host, port=port,
-                              db=db, socket_timeout=timeout, password=auth)
+                              db=db, socket_timeout=timeout, password=auth,
+                              unix_socket_path=unix_socket)
             cli.ping()
             return cli
         except Exception, ex:
             self.log.error("RedisCollector: failed to connect to %s:%i. %s.",
-                           host, port, ex)
+                           unix_socket or host, port, ex)
 
     def _precision(self, value):
         """Return the precision of the number
@@ -206,7 +223,7 @@ class RedisCollector(diamond.collector.Collector):
         """
         return '%s.%s' % (nick, key)
 
-    def _get_info(self, host, port, auth):
+    def _get_info(self, host, port, unix_socket, auth):
         """Return info dict from specified Redis instance
 
 :param str host: redis host
@@ -215,7 +232,7 @@ class RedisCollector(diamond.collector.Collector):
 
         """
 
-        client = self._client(host, port, auth)
+        client = self._client(host, port, unix_socket, auth)
         if client is None:
             return None
 
@@ -223,17 +240,19 @@ class RedisCollector(diamond.collector.Collector):
         del client
         return info
 
-    def collect_instance(self, nick, host, port, auth):
+    def collect_instance(self, nick, host, port, unix_socket, auth):
         """Collect metrics from a single Redis instance
 
 :param str nick: nickname of redis instance
 :param str host: redis host
 :param int port: redis port
+:param str unix_socket: unix socket, if applicable
+:param str auth: authentication password
 
         """
 
         # Connect to redis and get the info
-        info = self._get_info(host, port, auth)
+        info = self._get_info(host, port, unix_socket, auth)
         if info is None:
             return
 
@@ -280,5 +299,5 @@ class RedisCollector(diamond.collector.Collector):
             return {}
 
         for nick in self.instances.keys():
-            (host, port, auth) = self.instances[nick]
-            self.collect_instance(nick, host, int(port), auth)
+            (host, port, unix_socket, auth) = self.instances[nick]
+            self.collect_instance(nick, host, int(port), unix_socket, auth)

--- a/src/collectors/redisstat/redisstat.py
+++ b/src/collectors/redisstat/redisstat.py
@@ -30,9 +30,29 @@ enabled=True
 instances = nick1@host1:port1, nick2@host2:port2/PASSWORD, ...
 ```
 
+For connecting via unix sockets, provide the path prefixed with ``unix:``
+instead of the host, e.g.
+
+```
+enabled=True
+host=unix:/var/run/redis/redis.sock
+```
+
+or
+
+```
+enabled = True
+instances = nick3@unix:/var/run/redis.sock:/PASSWORD
+```
+
+In that case, for disambiguation there must be a colon ``:`` before the slash
+``/`` followed by the password.
+
 Note: when using the host/port config mode, the port number is used in
 the metric key. When using the multi-instance mode, the nick will be used.
-If not specified the port will be used.
+If not specified the port will be used. In case of unix sockets, the base name
+without file extension (i.e. in the aforementioned examples ``redis``)
+is the default metric key.
 
 
 """
@@ -117,7 +137,7 @@ class RedisCollector(diamond.collector.Collector):
                 auth = port_auth.partition('/')[2] or None
 
                 if nickname is None:
-                    nickname = os.path.basename(unix_socket)
+                    nickname = os.path.splitext(os.path.basename(unix_socket))[0]
                 self.instances[nickname] = (self._DEFAULT_HOST, self._DEFAULT_PORT, unix_socket, auth)
             else:
                 if '/' in hostport:

--- a/src/collectors/redisstat/test/testredisstat.py
+++ b/src/collectors/redisstat/test/testredisstat.py
@@ -210,19 +210,26 @@ class TestRedisCollector(CollectorTestCase):
             },
             'unix_socket_host_set': {
                 'config': {'host': 'unix:/var/run/redis/myhost.sock'},
-                'calls': [call('myhost', 'localhost', 6379, '/var/run/redis/myhost.sock', None)],
+                'calls': [call('myhost', 'localhost', 6379,
+                               '/var/run/redis/myhost.sock', None)],
             },
             'instance_1_host': {
                 'config': {'instances': ['nick@myhost']},
                 'calls': [call('nick', 'myhost', 6379, None, None)],
             },
             'unix_socket_instance_1_host': {
-                'config': {'instances': ['nick@unix:/var/run/redis/myhost.sock']},
-                'calls': [call('nick', 'localhost', 6379, '/var/run/redis/myhost.sock', None)],
+                'config': {'instances': [
+                    'nick@unix:/var/run/redis/myhost.sock'
+                ]},
+                'calls': [call('nick', 'localhost', 6379,
+                               '/var/run/redis/myhost.sock', None)],
             },
             'unix_socket_instance_1_hostauth': {
-                'config': {'instances': ['nick@unix:/var/run/redis/myhost.sock:/pass']},
-                'calls': [call('nick', 'localhost', 6379, '/var/run/redis/myhost.sock', 'pass')],
+                'config': {'instances': [
+                    'nick@unix:/var/run/redis/myhost.sock:/pass'
+                ]},
+                'calls': [call('nick', 'localhost', 6379,
+                               '/var/run/redis/myhost.sock', 'pass')],
             },
             'instance_1_port': {
                 'config': {'instances': ['nick@:9191']},
@@ -233,11 +240,16 @@ class TestRedisCollector(CollectorTestCase):
                 'calls': [call('nick', 'host1', 8765, None, None)],
             },
             'instance_2': {
-                'config': {'instances': ['foo@hostX', 'bar@:1000/pass', 'unix:/var/run/redis/myhost.sock:1/pass']},
+                'config': {'instances': [
+                    'foo@hostX',
+                    'bar@:1000/pass',
+                    'unix:/var/run/redis/myhost.sock:1/pass'
+                ]},
                 'calls': [
                     call('foo', 'hostX', 6379, None, None),
                     call('bar', 'localhost', 1000, None, 'pass'),
-                    call('myhost', 'localhost', 6379, '/var/run/redis/myhost.sock', 'pass'),
+                    call('myhost', 'localhost', 6379,
+                         '/var/run/redis/myhost.sock', 'pass'),
                 ],
             },
             'old_and_new': {

--- a/src/collectors/redisstat/test/testredisstat.py
+++ b/src/collectors/redisstat/test/testredisstat.py
@@ -190,37 +190,54 @@ class TestRedisCollector(CollectorTestCase):
         testcases = {
             'default': {
                 'config': {},  # test default settings
-                'calls': [call('6379', 'localhost', 6379, None)],
+                'calls': [call('6379', 'localhost', 6379, None, None)],
             },
             'host_set': {
                 'config': {'host': 'myhost'},
-                'calls': [call('6379', 'myhost', 6379, None)],
+                'calls': [call('6379', 'myhost', 6379, None, None)],
             },
             'port_set': {
                 'config': {'port': 5005},
-                'calls': [call('5005', 'localhost', 5005, None)],
+                'calls': [call('5005', 'localhost', 5005, None, None)],
             },
             'hostport_set': {
                 'config': {'host': 'megahost', 'port': 5005},
-                'calls': [call('5005', 'megahost', 5005, None)],
+                'calls': [call('5005', 'megahost', 5005, None, None)],
+            },
+            'portauth_set': {
+                'config': {'port': 5005, 'auth': 'pass'},
+                'calls': [call('5005', 'localhost', 5005, None, 'pass')],
+            },
+            'unix_socket_host_set': {
+                'config': {'host': 'unix:/var/run/redis/myhost.sock'},
+                'calls': [call('myhost', 'localhost', 6379, '/var/run/redis/myhost.sock', None)],
             },
             'instance_1_host': {
                 'config': {'instances': ['nick@myhost']},
-                'calls': [call('nick', 'myhost', 6379, None)],
+                'calls': [call('nick', 'myhost', 6379, None, None)],
+            },
+            'unix_socket_instance_1_host': {
+                'config': {'instances': ['nick@unix:/var/run/redis/myhost.sock']},
+                'calls': [call('nick', 'localhost', 6379, '/var/run/redis/myhost.sock', None)],
+            },
+            'unix_socket_instance_1_hostauth': {
+                'config': {'instances': ['nick@unix:/var/run/redis/myhost.sock:/pass']},
+                'calls': [call('nick', 'localhost', 6379, '/var/run/redis/myhost.sock', 'pass')],
             },
             'instance_1_port': {
                 'config': {'instances': ['nick@:9191']},
-                'calls': [call('nick', 'localhost', 9191, None)],
+                'calls': [call('nick', 'localhost', 9191, None, None)],
             },
             'instance_1_hostport': {
                 'config': {'instances': ['nick@host1:8765']},
-                'calls': [call('nick', 'host1', 8765, None)],
+                'calls': [call('nick', 'host1', 8765, None, None)],
             },
             'instance_2': {
-                'config': {'instances': ['foo@hostX', 'bar@:1000']},
+                'config': {'instances': ['foo@hostX', 'bar@:1000/pass', 'unix:/var/run/redis/myhost.sock:1/pass']},
                 'calls': [
-                    call('foo', 'hostX', 6379, None),
-                    call('bar', 'localhost', 1000, None)
+                    call('foo', 'hostX', 6379, None, None),
+                    call('bar', 'localhost', 1000, None, 'pass'),
+                    call('myhost', 'localhost', 6379, '/var/run/redis/myhost.sock', 'pass'),
                 ],
             },
             'old_and_new': {
@@ -235,10 +252,10 @@ class TestRedisCollector(CollectorTestCase):
                     ]
                 },
                 'calls': [
-                    call('foo', 'hostX', 6379, None),
-                    call('bar', 'localhost', 1000, None),
-                    call('6379', 'hostonly', 6379, None),
-                    call('1234', 'localhost', 1234, None),
+                    call('foo', 'hostX', 6379, None, None),
+                    call('bar', 'localhost', 1000, None, None),
+                    call('6379', 'hostonly', 6379, None, None),
+                    call('1234', 'localhost', 1234, None, None),
                 ],
             },
         }


### PR DESCRIPTION
The Redis client for Python supports connections via unix sockets.

This PR considers a ``unix:`` prefix in the RedisCollector ``host`` / ``instances`` configuration for this connection type.