### PR TITLE
Update Makefile so RPM will have python-configobj as a dependancy, this ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ rpm: buildrpm
 buildrpm: sdist
 	./setup.py bdist_rpm \
 		--release=`ls dist/*.noarch.rpm | wc -l` \
-		--build-requires='python' \
-		--requires='python'
+		--build-requires='python, python-configobj' \
+		--requires='python, python-configobj'
 
 deb: builddeb
 


### PR DESCRIPTION
The only change in the PR is to include the python-configobj package as a dependency when building the rpm. Currently you can build the RPM, install it and you will only be notified when you attempt to start the service that you need this package installed.