### PR TITLE
Setting a precision for publish for sub MS ping times

### DIFF
--- a/src/collectors/ping/ping.py
+++ b/src/collectors/ping/ping.py
@@ -80,4 +80,4 @@ class PingCollector(diamond.collector.ProcessCollector):
                 else:
                     metric_value = 10000
 
-                self.publish(metric_name, metric_value)
+                self.publish(metric_name, metric_value, precision=4)

--- a/src/collectors/ping/test/fixtures/fasthost_gentoo
+++ b/src/collectors/ping/test/fixtures/fasthost_gentoo
@@ -1,0 +1,5 @@
+PING www.example.com (192.0.43.10) 56(84) bytes of data.
+
+--- www.example.com ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time 0ms
+rtt min/avg/max/mdev = 0.162/0.162/0.162/0.000 ms

--- a/src/collectors/ping/test/fixtures/fasthost_osx
+++ b/src/collectors/ping/test/fixtures/fasthost_osx
@@ -1,0 +1,5 @@
+PING www.example.com (192.0.43.10): 56 data bytes
+
+--- www.example.com ping statistics ---
+1 packets transmitted, 1 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 0.162/0.162/0.162/0.000 ms

--- a/src/collectors/ping/test/testping.py
+++ b/src/collectors/ping/test/testping.py
@@ -103,6 +103,24 @@ class TestPingCollector(CollectorTestCase):
 
     @patch('os.access', Mock(return_value=True))
     @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data_fasthost_gentoo(self, publish_mock):
+        patch_communicate = patch(
+            'subprocess.Popen.communicate',
+            Mock(return_value=(
+                self.getFixture(
+                    'fasthost_gentoo').getvalue(),
+                '')))
+
+        patch_communicate.start()
+        self.collector.collect()
+        patch_communicate.stop()
+
+        self.assertPublishedMany(publish_mock, {
+            'localhost': 0.162
+        })
+
+    @patch('os.access', Mock(return_value=True))
+    @patch.object(Collector, 'publish')
     def test_should_work_with_real_data_timeout_gentoo(self, publish_mock):
         patch_communicate = patch(
             'subprocess.Popen.communicate',
@@ -168,6 +186,23 @@ class TestPingCollector(CollectorTestCase):
 
         self.assertPublishedMany(publish_mock, {
             'localhost': 42
+        })
+
+    @patch('os.access', Mock(return_value=True))
+    @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data_fasthost_osx(self, publish_mock):
+        patch_communicate = patch(
+            'subprocess.Popen.communicate',
+            Mock(return_value=(
+                self.getFixture('fasthost_osx').getvalue(),
+                '')))
+
+        patch_communicate.start()
+        self.collector.collect()
+        patch_communicate.stop()
+
+        self.assertPublishedMany(publish_mock, {
+            'localhost': 0.162
         })
 
     @patch('os.access', Mock(return_value=True))


### PR DESCRIPTION
I needed to test ping times from servers to memcache servers in
SoftLayers network. We’d get > 50ms ping times randomly and bids would
fail taking too long to connect to memcache.

It’s possible to have sub MS response times as seen

```
64 bytes from memcache101.domain.com (10.102.74.173): icmp_seq=1 ttl=64
time=0.157 ms
64 bytes from memcache101.domain.com (10.102.74.173): icmp_seq=2 ttl=64
time=0.148 ms
64 bytes from memcache101.domain.com (10.102.74.173): icmp_seq=3 ttl=64
time=0.155 ms
64 bytes from memcache101.domain.com (10.102.74.173): icmp_seq=4 ttl=64
time=0.124 ms
```

without the precision in there it would send metric to graphite like

0.0000
