### PR TITLE
JolokiaCollector: collect from multiple instances

### DIFF
--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -26,10 +26,18 @@ will be queried for metrics.
 JolokiaCollector.conf
 
 ```
-    host 'localhost'
-    port '8778'
-    mbeans '"java.lang:name=ParNew,type=GarbageCollector | org.apache.cassandra.metrics:name=WriteTimeouts,type=ClientRequestMetrics"' # noqa
+    host='localhost'
+    port='8778'
+    mbeans='java.lang:name=ParNew,type=GarbageCollector|org.apache.cassandra.metrics:name=WriteTimeouts,type=ClientRequestMetrics' # noqa
 ```
+
+or for multi-instance mode:
+
+```
+enabled=True
+instances = nick1@host1:port1, nick2@host2:port2, ...
+```
+
 """
 
 import diamond.collector
@@ -60,6 +68,9 @@ class JolokiaCollector(diamond.collector.Collector):
             "stats. If not provided, all stats will be collected",
             'host': 'Hostname',
             'port': 'Port',
+            'instances': "Jolokia addresses, comma separated, syntax:"
+            + " nick1@host:port, nick2@host:port"
+
         })
         return config_help
 
@@ -70,17 +81,40 @@ class JolokiaCollector(diamond.collector.Collector):
             'path': 'jmx',
             'host': 'localhost',
             'port': 8778,
+            'instances': [],
         })
         return config
 
     def process_config(self):
         super(JolokiaCollector, self).process_config()
+
+        self.instances = {}
+        self._create_instances()
+
         self.mbeans = []
         if isinstance(self.config['mbeans'], basestring):
             for mbean in self.config['mbeans'].split('|'):
                 self.mbeans.append(mbean.strip())
         elif isinstance(self.config['mbeans'], list):
             self.mbeans = self.config['mbeans']
+
+    def _create_instances(self):
+        """
+        Shoves the list of instances from instance_list to self.instances
+        or uses the provided host and port.
+        """
+        instance_list = self.config['instances']
+        # configobj make str of single-element list, let's convert
+        if isinstance(instance_list, basestring):
+            instance_list = [instance_list]
+        for instance in instance_list:
+            (nickname, hostport) = instance.split('@', 1)
+            parts = hostport.split(':')
+            host = parts[0]
+            port = int(parts[1])
+            self.instances[nickname] = (host, port)
+        if len(self.instances) == 0:
+            self.instances[""] = (self.config["host"], int(self.config["port"]))
 
     def check_mbean(self, mbean):
         if mbean in self.mbeans or not self.mbeans:
@@ -89,39 +123,41 @@ class JolokiaCollector(diamond.collector.Collector):
             return False
 
     def collect(self):
-        listing = self.list_request()
-        try:
-            domains = listing['value'] if listing['status'] == 200 else {}
-            for domain in domains.keys():
-                if domain not in self.IGNORE_DOMAINS:
-                    obj = self.read_request(domain)
-                    mbeans = obj['value'] if obj['status'] == 200 else {}
-                    for k, v in mbeans.iteritems():
-                        if self.check_mbean(k):
-                            self.collect_bean(k, v)
-        except KeyError:
-            # The reponse was totally empty, or not an expected format
-            self.log.error('Unable to retrieve MBean listing.')
+        for instance_key in self.instances:
+            host, port = self.instances[instance_key]
+            listing = self.list_request(host, port)
+            try:
+                domains = listing['value'] if listing['status'] == 200 else {}
+                for domain in domains.keys():
+                    if domain not in self.IGNORE_DOMAINS:
+                        obj = self.read_request(domain, host, port)
+                        mbeans = obj['value'] if obj['status'] == 200 else {}
+                        for k, v in mbeans.iteritems():
+                            if self.check_mbean(k):
+                                self.collect_bean(k, v, instance_key)
+            except KeyError:
+                # The reponse was totally empty, or not an expected format
+                self.log.error('Unable to retrieve MBean listing.')
 
     def read_json(self, request):
         json_str = request.read()
         return json.loads(json_str)
 
-    def list_request(self):
+    def list_request(self, host, port):
         try:
-            url = "http://%s:%s/%s" % (self.config['host'],
-                                       self.config['port'], self.LIST_URL)
+            url = "http://%s:%s/%s" % (host,
+                                       port, self.LIST_URL)
             response = urllib2.urlopen(url)
             return self.read_json(response)
         except (urllib2.HTTPError, ValueError):
             self.log.error('Unable to read JSON response.')
             return {}
 
-    def read_request(self, domain):
+    def read_request(self, domain, host, port):
         try:
             url_path = self.READ_URL % urllib.quote(domain)
-            url = "http://%s:%s/%s" % (self.config['host'],
-                                       self.config['port'], url_path)
+            url = "http://%s:%s/%s" % (host,
+                                       port, url_path)
             response = urllib2.urlopen(url)
             return self.read_json(response)
         except (urllib2.HTTPError, ValueError):
@@ -134,16 +170,22 @@ class JolokiaCollector(diamond.collector.Collector):
         text = re.sub('["\']', '', text)
         return text
 
-    def collect_bean(self, prefix, obj):
+    def collect_bean(self, prefix, obj, instance_key):
+        if instance_key != "":
+            instance_prefix = "%s." % instance_key
+        else:
+            instance_prefix = ""
         for k, v in obj.iteritems():
             if type(v) in [int, float, long]:
-                key = "%s.%s" % (prefix, k)
+                key = "%s.%s%s" % (prefix, instance_prefix, k)
                 key = self.clean_up(key)
                 self.publish(key, v)
             elif type(v) in [dict]:
-                self.collect_bean("%s.%s" % (prefix, k), v)
+                self.collect_bean(
+                    "%s.%s%s" % (prefix, instance_prefix, k), v, "")
             elif type(v) in [list]:
-                self.interpret_bean_with_list("%s.%s" % (prefix, k), v)
+                self.interpret_bean_with_list(
+                    "%s.%s%s" % (prefix, instance_prefix, k), v)
 
     # There's no unambiguous way to interpret list values, so
     # this hook lets subclasses handle them.

--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -181,6 +181,8 @@ class JolokiaCollector(diamond.collector.Collector):
                 key = self.clean_up(key)
                 self.publish(key, v)
             elif type(v) in [dict]:
+                # only use instance_prefix once, set to "" in recursive
+                # calls.
                 self.collect_bean(
                     "%s%s.%s" % (instance_prefix, prefix, k), v, "")
             elif type(v) in [list]:

--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -68,8 +68,8 @@ class JolokiaCollector(diamond.collector.Collector):
             "stats. If not provided, all stats will be collected",
             'host': 'Hostname',
             'port': 'Port',
-            'instances': "Jolokia addresses, comma separated, syntax:"
-            + " nick1@host:port, nick2@host:port"
+            'instances': ("Jolokia addresses, comma separated, syntax:"
+                          " nick1@host:port, nick2@host:port")
 
         })
         return config_help

--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -177,15 +177,15 @@ class JolokiaCollector(diamond.collector.Collector):
             instance_prefix = ""
         for k, v in obj.iteritems():
             if type(v) in [int, float, long]:
-                key = "%s.%s%s" % (prefix, instance_prefix, k)
+                key = "%s%s.%s" % (instance_prefix, prefix, k)
                 key = self.clean_up(key)
                 self.publish(key, v)
             elif type(v) in [dict]:
                 self.collect_bean(
-                    "%s.%s%s" % (prefix, instance_prefix, k), v, "")
+                    "%s%s.%s" % (instance_prefix, prefix, k), v, "")
             elif type(v) in [list]:
                 self.interpret_bean_with_list(
-                    "%s.%s%s" % (prefix, instance_prefix, k), v)
+                    "%s%s.%s" % (instance_prefix, prefix, k), v)
 
     # There's no unambiguous way to interpret list values, so
     # this hook lets subclasses handle them.

--- a/src/collectors/jolokia/test/testjolokia.py
+++ b/src/collectors/jolokia/test/testjolokia.py
@@ -24,6 +24,26 @@ class TestJolokiaCollector(CollectorTestCase):
     def test_import(self):
         self.assertTrue(JolokiaCollector)
 
+    def test_one_instance(self):
+        self.assertEquals(self.collector.instances, {"": ('localhost', 8778)})
+
+    def test_multiple_instances(self):
+        config = get_collector_config('JolokiaCollector', {
+            "instances": ["foo@localhost:1234", "bar@example.com:7777"]})
+        collector = JolokiaCollector(config, None)
+        instances = collector.instances
+        self.assertEquals(len(instances), 2)
+        self.assertEquals(instances["foo"], ('localhost', 1234))
+        self.assertEquals(instances["bar"], ('example.com', 7777))
+
+    def test_single_instance(self):
+        config = get_collector_config('JolokiaCollector', {
+            "instances": ["foo@localhost:1234"]})
+        collector = JolokiaCollector(config, None)
+        instances = collector.instances
+        self.assertEquals(len(instances), 1)
+        self.assertEquals(instances["foo"], ('localhost', 1234))
+
     @patch.object(Collector, 'publish')
     def test_should_work_with_real_data(self, publish_mock):
         def se(url):
@@ -82,8 +102,8 @@ class TestJolokiaCollector(CollectorTestCase):
             self, interpret_bean_with_list_mock, publish_mock):
         self.collector.collect_bean('prefix', {
             'RecentWriteLatencyMicros': 100,
-            'RecentReadLatencyHistogramMicros': [1, 2, 3]
-        })
+            'RecentReadLatencyHistogramMicros': [1, 2, 3],
+        }, "")
         self.assertPublishedMany(publish_mock, {
             'prefix.RecentWriteLatencyMicros': 100
         })


### PR DESCRIPTION
This patch allows to collect data from multiple jolokia instances. It follows the syntax in the redisstat collector.
I wrote a couple of tests just to ensure the instances variable is parsed correctly and tested this locally with
a tomcat and just collected the same data twice.

```
enabled = True
instances = mytomcat@localhost:20094, mytomcat2@localhost:20094
```

Sample output in `archive.log`:

```
servers.vagrant-ci-setup-mifr.jmx.mytomcat.java.lang.type_Threading.DaemonThreadCount 31 1424556475
servers.vagrant-ci-setup-mifr.jmx.mytomcat.java.lang.type_Threading.CurrentThreadCpuTime 12729312069 1424556475
servers.vagrant-ci-setup-mifr.jmx.mytomcat.java.lang.type_Threading.TotalStartedThreadCount 58 1424556475
servers.vagrant-ci-setup-mifr.jmx.mytomcat2.java.lang.type_OperatingSystem.OpenFileDescriptorCount 74 1424556483
servers.vagrant-ci-setup-mifr.jmx.mytomcat2.java.lang.type_OperatingSystem.SystemLoadAverage 0 1424556483
servers.vagrant-ci-setup-mifr.jmx.mytomcat2.java.lang.type_OperatingSystem.FreeSwapSpaceSize 0 1424556483
```

When instances is not given `host` and `port` will be taken into account as before.
