### PR TITLE
[Postgres] Added more debug log

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -160,7 +160,11 @@ class PostgresqlCollector(diamond.collector.Collector):
         else:
             conn_args['database'] = 'postgres'
 
-        conn = psycopg2.connect(**conn_args)
+        try:
+            conn = psycopg2.connect(**conn_args)
+        except Exception, e:
+            self.log.error(e)
+            raise e
 
         # Avoid using transactions, set isolation level to autocommit
         conn.set_isolation_level(0)


### PR DESCRIPTION
because, if the database connection can not be established,
there is no error, and so it's really not easy to detect.