### PR TITLE
KafkaCollector > Fix the key_prefix issue

### DIFF
--- a/src/collectors/kafka/test/testkafka.py
+++ b/src/collectors/kafka/test/testkafka.py
@@ -105,7 +105,7 @@ class TestKafkaCollector(CollectorTestCase):
     def test_build_key_prefix(self):
         objectnames = [
             'kafka:type=kafka.logs.mytopic-1',
-            'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce'
+            'kafka:type=RequestMetrics,name=RequestsPerSec,request=Produce'
         ]
 
         expected = [

--- a/src/collectors/kafka/test/testkafka.py
+++ b/src/collectors/kafka/test/testkafka.py
@@ -102,6 +102,25 @@ class TestKafkaCollector(CollectorTestCase):
         self.assertEqual(found_beans, None)
 
     @run_only_if_ElementTree_is_available
+    def test_build_key_prefix(self):
+        objectnames = [
+            'kafka:type=kafka.logs.mytopic-1',
+            'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce'
+        ]
+
+        expected = [
+            'kafka.logs.mytopic-1',
+            'RequestMetrics.RequestsPerSec.Produce'
+        ]
+
+        key_prefix = []
+
+        for objectname in objectnames:
+            key_prefix.append(self.collector.build_key_prefix(objectname))
+
+        self.assertEqual(key_prefix, expected)
+
+    @run_only_if_ElementTree_is_available
     @patch.object(KafkaCollector, '_get')
     def test_query_mbean(self, get_mock):
         get_mock.return_value = self._get_xml_fixture('mbean.xml')


### PR DESCRIPTION
It do not parse rightly the objectname that have more than 2 attributes.
For example,
kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce
=> RequestMetrics.RequestsPerSec,request.RequestsPerSec,request

It seems better to be parsed like this.
=> RequestMetrics.RequestsPerSec.Produce

I have defined the function that build the key_prefix as above.
