### PR TITLE
Updated PingCollector to work with v4 also v3

### DIFF
--- a/src/collectors/ping/ping.py
+++ b/src/collectors/ping/ping.py
@@ -16,9 +16,13 @@ Create a file named: PingCollector.conf in the collectors_config_path
 
  * enabled = true
  * interval = 60
- * target_1 = example.org
- * target_fw = 192.168.0.1
- * target_localhost = localhost
+ * target = example.org
+ * extended = true
+ * count = 10
+
+The extended and count are optional. If enabled extended will show
+min/max/avg/mdev for the results. Count will do more then a single
+ping to get those results.
 
 Test your configuration using the following command:
 
@@ -27,13 +31,23 @@ diamond-setup --print -C PingCollector
 You should get a response back that indicates 'enabled': True and see entries
 for your targets in pairs like:
 
-'target_1': 'example.org'
+'target': 'example.org'
 
-We extract out the key after target_ and use it in the graphite node we push.
+If you want multiple ping tests to be done name the configs like
+   - PingCollector google.conf
+   - PingCollector yahoo.conf
+
+A space in the config name will tell Diamond v4+ to run the collector multiple
+times
 
 """
 
 import diamond.collector
+from diamond.collector import str_to_bool
+
+import re
+import os
+import subprocess
 
 
 class PingCollector(diamond.collector.ProcessCollector):
@@ -41,7 +55,7 @@ class PingCollector(diamond.collector.ProcessCollector):
     def get_default_config_help(self):
         config_help = super(PingCollector, self).get_default_config_help()
         config_help.update({
-            'bin':         'The path to the ping binary',
+            'bin': 'The path to the ping binary',
         })
         return config_help
 
@@ -51,30 +65,63 @@ class PingCollector(diamond.collector.ProcessCollector):
         """
         config = super(PingCollector, self).get_default_config()
         config.update({
-            'path':             'ping',
-            'bin':              '/bin/ping',
+            'path': 'ping',
+            'bin': '/bin/ping',
+            'extended': 'false',
+            'count': '20',
         })
         return config
 
     def collect(self):
-        for key in self.config.keys():
-            if key[:7] == "target_":
-                host = self.config[key]
-                metric_name = host.replace('.', '_')
+        extended = str_to_bool(self.config['extended'])
 
-                ping = self.run_command(['-nq', '-c 1', host])
-                ping = ping[0].strip().split("\n")[-1]
+        #
+        # dump things into a dict to keep
+        # backward compatability with the
+        # old way of using the check
+        targets = {}
+        try:
+            targets[self.config['target']] = self.config['target']
+        except:
+            targets = dict(filter(lambda item: item[0].startswith('target_'),
+                                  self.config.iteritems()))
 
-                # Linux
-                if ping.startswith('rtt'):
-                    ping = ping.split()[3].split('/')[0]
-                    metric_value = float(ping)
-                # OS X
-                elif ping.startswith('round-trip '):
-                    ping = ping.split()[3].split('/')[0]
-                    metric_value = float(ping)
-                # Unknown
-                else:
-                    metric_value = 10000
+        if extended:
+            count = int(self.config['count'])
+        else:
+            count = 1
 
-                self.publish(metric_name, metric_value, precision=4)
+        for metric, host in targets.items():
+            ping = self.run_command(['-nq', '-c %i' % count, host])
+            ping = ping[0].strip().split("\n")[-1]
+
+            #
+            # set the metric name
+            metric = host.replace('.', '_')
+
+            try:
+                regstr = ('(?P<min>\d+.\d+)\/(?P<avg>\d+.\d+)\/',
+                          '(?P<max>\d+.\d+)\/(?P<mdev>\d+.\d+)')
+                regex = re.compile(regstr)
+                vals = regex.search(ping).groupdict()
+            except:
+                #
+                # something failed so log it and return
+                self.log.info("Failed to parse the ping output results")
+
+                vals = {
+                    'min': 0,
+                    'max': 0,
+                    'avg': 0,
+                    'mdev': 0
+                }
+
+            if extended:
+                for m, v in vals.items():
+                    metric_name = "%s.%s" % (metric, m)
+
+                    #
+                    # send to graphite
+                    self.publish(metric_name, v, precision=4)
+            else:
+                self.publish(metric, vals['min'], precision=4)

--- a/src/collectors/ping/ping.py
+++ b/src/collectors/ping/ping.py
@@ -80,4 +80,4 @@ class PingCollector(diamond.collector.ProcessCollector):
                 else:
                     metric_value = 10000
 
-                self.publish(metric_name, metric_value)
+                self.publish(metric_name, metric_value, precision=4)

--- a/src/collectors/ping/test/fixtures/fasthost_gentoo
+++ b/src/collectors/ping/test/fixtures/fasthost_gentoo
@@ -1,0 +1,5 @@
+PING www.example.com (192.0.43.10) 56(84) bytes of data.
+
+--- www.example.com ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time 0ms
+rtt min/avg/max/mdev = 0.162/0.162/0.162/0.000 ms

--- a/src/collectors/ping/test/fixtures/fasthost_osx
+++ b/src/collectors/ping/test/fixtures/fasthost_osx
@@ -1,0 +1,5 @@
+PING www.example.com (192.0.43.10): 56 data bytes
+
+--- www.example.com ping statistics ---
+1 packets transmitted, 1 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 0.162/0.162/0.162/0.000 ms

--- a/src/collectors/ping/test/testping.py
+++ b/src/collectors/ping/test/testping.py
@@ -103,6 +103,24 @@ class TestPingCollector(CollectorTestCase):
 
     @patch('os.access', Mock(return_value=True))
     @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data_fasthost_gentoo(self, publish_mock):
+        patch_communicate = patch(
+            'subprocess.Popen.communicate',
+            Mock(return_value=(
+                self.getFixture(
+                    'fasthost_gentoo').getvalue(),
+                '')))
+
+        patch_communicate.start()
+        self.collector.collect()
+        patch_communicate.stop()
+
+        self.assertPublishedMany(publish_mock, {
+            'localhost': 0.162
+        })
+
+    @patch('os.access', Mock(return_value=True))
+    @patch.object(Collector, 'publish')
     def test_should_work_with_real_data_timeout_gentoo(self, publish_mock):
         patch_communicate = patch(
             'subprocess.Popen.communicate',
@@ -168,6 +186,23 @@ class TestPingCollector(CollectorTestCase):
 
         self.assertPublishedMany(publish_mock, {
             'localhost': 42
+        })
+
+    @patch('os.access', Mock(return_value=True))
+    @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data_fasthost_osx(self, publish_mock):
+        patch_communicate = patch(
+            'subprocess.Popen.communicate',
+            Mock(return_value=(
+                self.getFixture('fasthost_osx').getvalue(),
+                '')))
+
+        patch_communicate.start()
+        self.collector.collect()
+        patch_communicate.stop()
+
+        self.assertPublishedMany(publish_mock, {
+            'localhost': 0.162
         })
 
     @patch('os.access', Mock(return_value=True))

--- a/src/collectors/ping/test/testpingextended.py
+++ b/src/collectors/ping/test/testpingextended.py
@@ -14,12 +14,14 @@ from ping import PingCollector
 ################################################################################
 
 
-class TestPingCollector(CollectorTestCase):
+class TestPingExtendedCollector(CollectorTestCase):
     def setUp(self):
         config = get_collector_config('PingCollector', {
             'interval': 10,
             'target_a': 'localhost',
-            'bin': 'true'
+            'bin': 'true',
+            'extended': 'true',
+            'count': '10'
         })
 
         self.collector = PingCollector(config, None)
@@ -41,7 +43,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 0
+            'localhost.min': 0,
+            'localhost.max': 0,
+            'localhost.avg': 0,
+            'localhost.mdev': 0
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -58,7 +63,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         metrics = {
-            'localhost': 11
+            'localhost.min': 10.607,
+            'localhost.max': 10.607,
+            'localhost.avg': 10.607,
+            'localhost.mdev': 0.000
         }
 
         self.setDocExample(collector=self.collector.__class__.__name__,
@@ -80,7 +88,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 0
+            'localhost.min': 0.063,
+            'localhost.max': 0.063,
+            'localhost.avg': 0.063,
+            'localhost.mdev': 0.000
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -98,7 +109,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 10
+            'localhost.min': 10.244,
+            'localhost.max': 10.244,
+            'localhost.avg': 10.244,
+            'localhost.mdev': 0.000
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -116,7 +130,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 0.162
+            'localhost.min': 0.162,
+            'localhost.max': 0.162,
+            'localhost.avg': 0.162,
+            'localhost.mdev': 0.000
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -134,7 +151,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 0
+            'localhost.min': 0,
+            'localhost.max': 0,
+            'localhost.avg': 0,
+            'localhost.mdev': 0
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -151,7 +171,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 38
+            'localhost.min': 38.088,
+            'localhost.max': 38.088,
+            'localhost.avg': 38.088,
+            'localhost.mdev': 0.000
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -168,7 +191,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 0
+            'localhost.min': 0.223,
+            'localhost.max': 0.223,
+            'localhost.avg': 0.223,
+            'localhost.mdev': 0.000
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -185,7 +211,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 42
+            'localhost.min': 41.621,
+            'localhost.max': 41.621,
+            'localhost.avg': 41.621,
+            'localhost.mdev': 0.000
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -202,7 +231,10 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 0.162
+            'localhost.min': 0.162,
+            'localhost.max': 0.162,
+            'localhost.avg': 0.162,
+            'localhost.mdev': 0
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -219,9 +251,11 @@ class TestPingCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'localhost': 0
+            'localhost.min': 0,
+            'localhost.max': 0,
+            'localhost.avg': 0,
+            'localhost.mdev': 0
         })
-
 ################################################################################
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is an updated ping collector to work with v4 forking but still work with v3 way of doing things. 

It adds two new config options

```
extended: (true|false)
count: number
```

It also changes the old format of `target_key = host` to just `target = host` 

If extended is enabled it will log the following

```
hostname.min: val
hostname.max: val
hostname.avg: val
hostname.mdev: val
```

A lot of times a single ping tells you nothing but the min/max/avg of 20-30 pings might be more telling. 

It's made to support the new forking by creating different configs with a space in the config to fork off a new process. It will also support the old way of doing it all in a single config. 