### PR TITLE
Don't join prefix if empty in Collector.get_metric_path.

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -182,7 +182,6 @@ class Collector(object):
         """
         Process a configfile, or reload if previously given one.
         """
-
         self.config = configobj.ConfigObj()
 
         # Load in the collector's defaults
@@ -351,11 +350,13 @@ class Collector(object):
         if suffix:
             prefix = '.'.join((prefix, suffix))
 
-        if path == '.' and prefix:
+        is_path_invalid = path == '.' or not path
+
+        if is_path_invalid and prefix:
             return '.'.join([prefix, name])
         elif prefix:
             return '.'.join([prefix, path, name])
-        elif path == '.':
+        elif is_path_invalid:
             return name
         else:
             return '.'.join([path, name])

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -351,10 +351,14 @@ class Collector(object):
         if suffix:
             prefix = '.'.join((prefix, suffix))
 
-        if path == '.':
+        if path == '.' and prefix:
             return '.'.join([prefix, name])
-        else:
+        elif prefix:
             return '.'.join([prefix, path, name])
+        elif path == '.':
+            return name
+        else:
+            return '.'.join([path, name])
 
     def get_hostname(self):
         return get_hostname(self.config)

--- a/src/diamond/test/testcollector.py
+++ b/src/diamond/test/testcollector.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 ################################################################################
 
+from mock import patch
 from test import unittest
 import configobj
 
@@ -32,3 +33,78 @@ class BaseCollectorTest(unittest.TestCase):
         }
         c = Collector(config, [])
         self.assertEquals('custom.localhost', c.get_hostname())
+
+    @patch('diamond.collector.get_hostname')
+    def test_get_metric_path_no_prefix(self, get_hostname_mock):
+
+        config = configobj.ConfigObj()
+        config['collectors'] = {}
+        config['collectors']['default'] = {}
+        config['collectors']['default']['path_prefix'] = ''
+        config['collectors']['default']['path'] = 'bar'
+
+        get_hostname_mock.return_value = None
+
+        result = Collector(config, []).get_metric_path('foo')
+
+        self.assertEqual('bar.foo', result)
+
+    @patch('diamond.collector.get_hostname')
+    def test_get_metric_path_no_prefix_no_path(self, get_hostname_mock):
+
+        config = configobj.ConfigObj()
+        config['collectors'] = {}
+        config['collectors']['default'] = {}
+        config['collectors']['default']['path_prefix'] = ''
+        config['collectors']['default']['path'] = ''
+
+        get_hostname_mock.return_value = None
+
+        result = Collector(config, []).get_metric_path('foo')
+
+        self.assertEqual('foo', result)
+
+    @patch('diamond.collector.get_hostname')
+    def test_get_metric_path_no_path(self, get_hostname_mock):
+
+        config = configobj.ConfigObj()
+        config['collectors'] = {}
+        config['collectors']['default'] = {}
+        config['collectors']['default']['path_prefix'] = 'bar'
+        config['collectors']['default']['path'] = ''
+
+        get_hostname_mock.return_value = None
+
+        result = Collector(config, []).get_metric_path('foo')
+
+        self.assertEqual('bar.foo', result)
+
+    @patch('diamond.collector.get_hostname')
+    def test_get_metric_path_dot_path(self, get_hostname_mock):
+
+        config = configobj.ConfigObj()
+        config['collectors'] = {}
+        config['collectors']['default'] = {}
+        config['collectors']['default']['path_prefix'] = 'bar'
+        config['collectors']['default']['path'] = '.'
+
+        get_hostname_mock.return_value = None
+
+        result = Collector(config, []).get_metric_path('foo')
+
+        self.assertEqual('bar.foo', result)
+
+    @patch('diamond.collector.get_hostname')
+    def test_get_metric_path(self, get_hostname_mock):
+
+        config = configobj.ConfigObj()
+        config['collectors'] = {}
+        config['collectors']['default'] = {}
+        config['collectors']['default']['path_prefix'] = 'poof'
+        config['collectors']['default']['path'] = 'xyz'
+
+        get_hostname_mock.return_value = 'bar'
+
+        result = Collector(config, []).get_metric_path('foo')
+
+        self.assertEqual('poof.bar.xyz.foo', result)


### PR DESCRIPTION
Fixes #123
