### PR TITLE
Add group for diamond at install time

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,8 +20,13 @@ set -e
 
 case "$1" in
     configure)
+        if ! getent group diamond >/dev/null ; then
+            addgroup --quiet --system diamond >/dev/null
+        fi
         if ! getent passwd diamond >/dev/null; then
-            adduser --quiet --system --no-create-home --home /var/log/diamond --shell /usr/sbin/nologin diamond
+            adduser --quiet --system --no-create-home --home /var/log/diamond \
+            --ingroup diamond \
+            --shell /usr/sbin/nologin diamond
         fi
     ;;
 
@@ -47,6 +52,6 @@ chmod -x /usr/bin/diamond
 chmod +x /usr/bin/diamond
 
 # Log / Run directory permissions
-chown -R diamond /var/log/diamond
+chown -R diamond:diamond /var/log/diamond
 
 exit 0


### PR DESCRIPTION
Also add a diamond group when installing the Debian package.
Fixes python-diamond/Diamond#80