### PR TITLE
Add MemAvailable to default keys.

### DIFF
--- a/src/collectors/memory/memory.py
+++ b/src/collectors/memory/memory.py
@@ -23,6 +23,7 @@ except ImportError:
     psutil = None
 
 _KEY_MAPPING = [
+    'MemAvailable',
     'MemTotal',
     'MemFree',
     'Buffers',


### PR DESCRIPTION
Now that `MemAvailable` is published by default when using `psutil` (a.k.a., when `/proc/meminfo` does not exist), I think it should be consistent that `MemAvailable` is published by default when using `/proc/meminfo`. Besides consistency reasons, it is really the only metric that tells the user how much memory is being used on the machine.