### PR TITLE
Fix UnboundLocalError if handlers_path is already a list

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -79,9 +79,10 @@ class Server(object):
         ########################################################################
 
         if 'handlers_path' in self.config['server']:
+            handlers_path = self.config['server']['handlers_path']
+
             # Make an list if not one
-            if isinstance(self.config['server']['handlers_path'], basestring):
-                handlers_path = self.config['server']['handlers_path']
+            if isinstance(handlers_path, basestring):
                 handlers_path = handlers_path.split(',')
                 handlers_path = map(str.strip, handlers_path)
                 self.config['server']['handlers_path'] = handlers_path


### PR DESCRIPTION
I was experimenting a bit with comma separated paths and ran into an UnboundLocalError in server.py. This change should guard against that situation.