### PR TITLE
Add Scribe collector

### DIFF
--- a/src/collectors/scribe/scribe.py
+++ b/src/collectors/scribe/scribe.py
@@ -1,0 +1,78 @@
+# coding=utf-8
+
+"""
+Collect counters from scribe
+
+#### Dependencies
+
+    * /usr/sbin/scribe_ctrl, distributed with scribe
+
+"""
+
+import subprocess
+import string
+
+import diamond.collector
+
+
+class ScribeCollector(diamond.collector.Collector):
+
+    def get_default_config_help(self):
+        config_help = super(ScribeCollector, self).get_default_config_help()
+        config_help.update({
+            'scribe_ctrl_bin': 'Path to scribe_ctrl binary',
+            'scribe_port': 'Scribe port',
+        })
+        return config_help
+
+    def get_default_config(self):
+        config = super(ScribeCollector, self).get_default_config()
+        config.update({
+            'path': 'scribe',
+            'scribe_ctrl_bin': self.find_binary('/usr/sbin/scribe_ctrl'),
+            'scribe_port': None,
+        })
+        return config
+
+    def key_to_metric(self, key):
+        """Replace all non-letter characters with underscores"""
+        return ''.join(l if l in string.letters else '_' for l in key)
+
+    def get_scribe_ctrl_output(self):
+        cmd = [self.config['scribe_ctrl_bin'], 'counters']
+
+        if self.config['scribe_port'] is not None:
+            cmd.append(self.config['scribe_port'])
+
+        self.log.debug("Running command %r", cmd)
+
+        try:
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        except OSError:
+            self.log.exception("Unable to run %r", cmd)
+            return ""
+
+        stdout, stderr = p.communicate()
+
+        if p.wait() != 0:
+            self.log.warning("Command failed %r", cmd)
+            self.log.warning(stderr)
+
+        return stdout
+
+    def get_scribe_stats(self):
+        output = self.get_scribe_ctrl_output()
+
+        data = {}
+
+        for line in output.splitlines():
+            key, val = line.rsplit(':', 1)
+            metric = self.key_to_metric(key)
+            data[metric] = int(val)
+
+        return data.items()
+
+    def collect(self):
+        for stat, val in self.get_scribe_stats():
+            self.publish(stat, val)

--- a/src/collectors/scribe/test/fixtures/scribe_ctrl
+++ b/src/collectors/scribe/test/fixtures/scribe_ctrl
@@ -1,0 +1,9 @@
+retries: 1
+lost: 4807542
+scribe overall:sent since last reconnect: 0
+received good: 9702186773
+sent since last reconnect: 9697379033
+denied for queue size: 33
+denied for total queue size: 44545
+denied for rate: 18
+sent: 9697379033

--- a/src/collectors/scribe/test/fixtures/scribe_ctrl_stats.json
+++ b/src/collectors/scribe/test/fixtures/scribe_ctrl_stats.json
@@ -1,0 +1,11 @@
+{
+    "retries": 1,
+    "lost": 4807542,
+    "scribe_overall_sent_since_last_reconnect": 0,
+    "received_good": 9702186773,
+    "sent_since_last_reconnect": 9697379033,
+    "denied_for_queue_size": 33,
+    "denied_for_total_queue_size": 44545,
+    "denied_for_rate": 18,
+    "sent": 9697379033
+}

--- a/src/collectors/scribe/test/test_scribe.py
+++ b/src/collectors/scribe/test/test_scribe.py
@@ -1,0 +1,36 @@
+import json
+
+from test import CollectorTestCase
+from test import get_collector_config
+
+from mock import Mock, patch
+
+from scribe import ScribeCollector
+
+
+class ScribeCollectorTestCase(CollectorTestCase):
+
+    def setUp(self):
+        config = get_collector_config('ScribeCollector', {})
+        self.collector = ScribeCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(ScribeCollector)
+
+    def test_key_to_metric(self):
+        fn = self.collector.key_to_metric
+        self.assertEqual(fn("foo! bar!"), "foo__bar_")
+        self.assertEqual(fn(" foo:BAR"), "_foo_BAR")
+        self.assertEqual(fn("the_same"), "the_same")
+
+    def test_get_scribe_stats(self):
+        scribe_ctrl_output = self.getFixture('scribe_ctrl').getvalue()
+        expected_scribe_stats = json.loads(self.getFixture(
+                                           'scribe_ctrl_stats.json')
+                                           .getvalue())
+
+        with patch.object(ScribeCollector, 'get_scribe_ctrl_output',
+                          Mock(return_value=scribe_ctrl_output)):
+            scribe_stats = self.collector.get_scribe_stats()
+
+        self.assertEqual(dict(scribe_stats), expected_scribe_stats)


### PR DESCRIPTION
The `scribe_ctrl` utility distributed with Scribe can expose some useful counters within the daemon. For example:

```
$ scribe_ctrl counters
retries: 43674
scribe overall:sent since last reconnect: 0
received good: 93209803
sent since last reconnect: 93208683
denied for queue size: 397
received blank category: 1
sent: 93208683
```

This collector parses this output, sanitizes the metric names, and publishes the results.