### PR TITLE
(minor) add ncpus metric - amount of CPU threads

### DIFF
--- a/src/collectors/cpu/cpu.py
+++ b/src/collectors/cpu/cpu.py
@@ -144,6 +144,7 @@ class CPUCollector(diamond.collector.Collector):
             file.close()
 
             metrics = {}
+            metrics['ncpus'] = ncpus
 
             for cpu in results.keys():
                 stats = results[cpu]


### PR DESCRIPTION
Hi,

This is micro-minor pull request to add metric 'ncpus' for CPU collector. It's quite useful to have this metric. If CPU collector reports only totals, i.e. %, ncpus provides information about amount of used cores / threads. 