### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ else:
         ('share/diamond/user_scripts', []),
     ]
 
-    distro = platform.dist()[0]
-    distro_major_version = platform.dist()[1].split('.')[0]
+    distro = platform.linux_distribution()[0]
+    distro_major_version = platform.linux_distribution()[1].split('.')[0]
 
     if running_under_virtualenv():
         data_files.append(('etc/diamond',


### PR DESCRIPTION
According to the document(https://docs.python.org/2/library/platform.html), the dist function deprecated since version 2.6.