### PR TITLE
Fix elb_names

### DIFF
--- a/src/collectors/elb/elb.py
+++ b/src/collectors/elb/elb.py
@@ -226,7 +226,7 @@ class ElbCollector(diamond.collector.Collector):
                     continue
                 elb_names.append(elb_name)
         else:
-            elb_names = region_dict['elb_names']
+            elb_names = [i.rstrip().lstrip() for i in region_dict['elb_names'].split(',')]
         return elb_names
 
     def process_stat(self, region, zone, elb_name, metric, stat, end_time):


### PR DESCRIPTION
turn string into ``,`` separated list

If elb_names is specified it just ``process_elb`` trough every chars that made it's names