### PR TITLE
Update JolokiaCollectors to forward all args and kwargs to the superclass

### DIFF
--- a/src/collectors/jolokia/cassandra_jolokia.py
+++ b/src/collectors/jolokia/cassandra_jolokia.py
@@ -49,8 +49,8 @@ class CassandraJolokiaCollector(JolokiaCollector):
         })
         return config
 
-    def __init__(self, config, handlers):
-        super(CassandraJolokiaCollector, self).__init__(config, handlers)
+    def __init__(self, *args, **kwargs):
+        super(CassandraJolokiaCollector, self).__init__(*args, **kwargs)
         self.offsets = self.create_offsets(91)
         self.update_config(self.config)
 

--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -97,8 +97,8 @@ class JolokiaCollector(diamond.collector.Collector):
         })
         return config
 
-    def __init__(self, config, handlers):
-        super(JolokiaCollector, self).__init__(config, handlers)
+    def __init__(self, *args, **kwargs):
+        super(JolokiaCollector, self).__init__(*args, **kwargs)
         self.mbeans = []
         self.rewrite = {}
         if isinstance(self.config['mbeans'], basestring):


### PR DESCRIPTION
After #149, I'm unable to use the JolokiaCollector and get this error when trying to use it:

```
[2015-04-27 09:30:34,088] [MainThread] Failed to initialize Collector: JolokiaCollector. Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/diamond/utils/classes.py", line 203, in initialize_collector
    collector = cls(name=name, configfile=configfile, handlers=handlers)
TypeError: __init__() got an unexpected keyword argument 'configfile'

[2015-04-27 09:30:34,088] [MainThread] Failed to load collector JolokiaCollector
```