### PR TITLE
Log exceptions from collectors

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -481,6 +481,8 @@ class Collector(object):
                     metric_name = 'collector_time_ms'
                     metric_value = collector_time
                     self.publish(metric_name, metric_value)
+        except Exception, e:
+            self.log.exception(e)
         finally:
             # After collector run, invoke a flush
             # method on each handler.


### PR DESCRIPTION
Here's some code to log exceptions from collector runs.

I'm using diamond from latest pip (4.0.41), and it contains a bug in processresources.py.  However, it was silently failing because collector.py swallowed the exception without logging it.

It's not relevant to this PR, but for the record, the bug I hit in processresources.py was fixed by this commit:  023895b5bea4295e738056e398515e8e273a97b1
