### PR TITLE
Add config filename to error messages from parsing collector config file...

### DIFF
--- a/src/diamond/utils/config.py
+++ b/src/diamond/utils/config.py
@@ -99,7 +99,12 @@ def load_config(configfile):
                 if collector not in config['collectors']:
                     config['collectors'][collector] = configobj.ConfigObj()
 
-                newconfig = configobj.ConfigObj(cfgfile)
+                try:
+                    newconfig = configobj.ConfigObj(cfgfile)
+                except Exception, e:
+                    raise Exception("Failed to load config file %s due to %s" %
+                                    (cfgfile, e))
+
                 config['collectors'][collector].merge(newconfig)
 
     # Convert enabled to a bool


### PR DESCRIPTION
Supposed you had a syntax error in a collector config file, like:

    enabled = True
    enabled = True

In this case, you get an error message that says
> Duplicate keyword name at line 3.

Good explanation, but it can require looking through dozens of config files to figure out which one is causing the error.

A better error message is produced by this PR:
> Failed to load config file /etc/diamond/collectors/VMStatCollector.conf due to Duplicate keyword name at line 3.