### PR TITLE
Enable psutil2 support

### DIFF
--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -152,6 +152,7 @@ class ProcessResourcesCollector(diamond.collector.Collector):
         'num_fds',
         'memory_percent',
         'ext_memory_info',
+        'memory_info_ex'
     ]
 
     def save_process_info(self, pg_name, process_info):

--- a/src/collectors/processresources/test/testprocessresources.py
+++ b/src/collectors/processresources/test/testprocessresources.py
@@ -222,13 +222,13 @@ class ProcessMock:
         ionice = namedtuple('ionice', 'ioclass value')
         amount = namedtuple('amount', 'voluntary involuntary')
         ext_memory_info = ext_meminfo(
-                                       rss=self.rss,
-                                       vms=self.vms,
-                                       shared=1310720,
-                                       text=188416,
-                                       lib=0,
-                                       data=868352,
-                                       dirty=0)
+            rss=self.rss,
+            vms=self.vms,
+            shared=1310720,
+            text=188416,
+            lib=0,
+            data=868352,
+            dirty=0)
         all = {
             'status': 'sleeping',
             'num_ctx_switches': amount(voluntary=2243, involuntary=221),

--- a/src/collectors/processresources/test/testprocessresources.py
+++ b/src/collectors/processresources/test/testprocessresources.py
@@ -25,6 +25,7 @@ def run_only_if_psutil_is_available(func):
 
 SELFMON_PID = 10001  # used for selfmonitoring
 
+
 class TestProcessResourcesCollector(CollectorTestCase):
     TEST_CONFIG = {
         'interval': 10,
@@ -195,6 +196,7 @@ class TestProcessResourcesCollector(CollectorTestCase):
         self.assertPublished(publish_mock,
                              'diamond-selfmon.memory_info_ex.rss', 1234)
 
+
 class ProcessMock:
     def __init__(self, pid, name, rss, vms, exe=None, psutil=1):
         self.pid = pid
@@ -219,7 +221,8 @@ class ProcessMock:
         group = namedtuple('group', 'real effective saved')
         ionice = namedtuple('ionice', 'ioclass value')
         amount = namedtuple('amount', 'voluntary involuntary')
-        ext_memory_info = ext_meminfo(rss=self.rss,
+        ext_memory_info = ext_meminfo(
+                                       rss=self.rss,
                                        vms=self.vms,
                                        shared=1310720,
                                        text=188416,

--- a/src/collectors/processresources/test/testprocessresources.py
+++ b/src/collectors/processresources/test/testprocessresources.py
@@ -23,6 +23,7 @@ def run_only_if_psutil_is_available(func):
         psutil = None
     return run_only(func, lambda: psutil is not None)
 
+SELFMON_PID = 10001  # used for selfmonitoring
 
 class TestProcessResourcesCollector(CollectorTestCase):
     TEST_CONFIG = {
@@ -46,7 +47,81 @@ class TestProcessResourcesCollector(CollectorTestCase):
             }
         }
     }
-    SELFMON_PID = 10001  # used for selfmonitoring
+
+    PROCESS_INFO_LIST = [
+        # postgres processes
+        {
+            'exe': '/usr/lib/postgresql/9.1/bin/postgres',
+            'name': 'postgres',
+            'pid': 1427,
+            'rss': 1000000,
+            'vms': 1000000
+        },
+        {
+            'exe': '',
+            'name': 'postgres: writer process   ',
+            'pid': 1445,
+            'rss': 100000,
+            'vms': 200000
+        },
+        {
+            'exe': '',
+            'name': 'postgres: wal writer process   ',
+            'pid': 1446,
+            'rss': 10000,
+            'vms': 20000
+        },
+        {
+            'exe': '',
+            'name': 'postgres: autovacuum launcher process   ',
+            'pid': 1447,
+            'rss': 1000,
+            'vms': 2000
+        },
+        {
+            'exe': '',
+            'name': 'postgres: stats collector process   ',
+            'pid': 1448,
+            'rss': 100,
+            'vms': 200},
+        # postgres-y process
+        {
+            'exe': '',
+            'name': 'posgre: not really',
+            'pid': 9999,
+            'rss': 10,
+            'vms': 20,
+        },
+        {
+            'exe': '/usr/bin/foo',
+            'name': 'bar',
+            'pid': 9998,
+            'rss': 1,
+            'vms': 1
+        },
+        {
+            'exe': '',
+            'name': 'barein',
+            'pid': 9997,
+            'rss': 2,
+            'vms': 2
+        },
+        {
+            'exe': '/usr/bin/bar',
+            'name': '',
+            'pid': 9996,
+            'rss': 3,
+            'vms': 3,
+        },
+        # diamond self mon process
+        {
+            'exe': 'DUMMY',
+            'name': 'DUMMY',
+            'pid': SELFMON_PID,
+            'rss': 1234,
+            'vms': 4,
+        },
+    ]
 
     def setUp(self):
         config = get_collector_config('ProcessResourcesCollector',
@@ -62,151 +137,17 @@ class TestProcessResourcesCollector(CollectorTestCase):
     @patch.object(os, 'getpid')
     @patch.object(Collector, 'publish')
     def test(self, publish_mock, getpid_mock, time_mock):
-        process_info_list = [
-            # postgres processes
-            {
-                'exe': '/usr/lib/postgresql/9.1/bin/postgres',
-                'name': 'postgres',
-                'pid': 1427,
-                'rss': 1000000,
-                'vms': 1000000
-            },
-            {
-                'exe': '',
-                'name': 'postgres: writer process   ',
-                'pid': 1445,
-                'rss': 100000,
-                'vms': 200000
-            },
-            {
-                'exe': '',
-                'name': 'postgres: wal writer process   ',
-                'pid': 1446,
-                'rss': 10000,
-                'vms': 20000
-            },
-            {
-                'exe': '',
-                'name': 'postgres: autovacuum launcher process   ',
-                'pid': 1447,
-                'rss': 1000,
-                'vms': 2000
-            },
-            {
-                'exe': '',
-                'name': 'postgres: stats collector process   ',
-                'pid': 1448,
-                'rss': 100,
-                'vms': 200},
-            # postgres-y process
-            {
-                'exe': '',
-                'name': 'posgre: not really',
-                'pid': 9999,
-                'rss': 10,
-                'vms': 20,
-            },
-            {
-                'exe': '/usr/bin/foo',
-                'name': 'bar',
-                'pid': 9998,
-                'rss': 1,
-                'vms': 1
-            },
-            {
-                'exe': '',
-                'name': 'barein',
-                'pid': 9997,
-                'rss': 2,
-                'vms': 2
-            },
-            {
-                'exe': '/usr/bin/bar',
-                'name': '',
-                'pid': 9996,
-                'rss': 3,
-                'vms': 3,
-            },
-            # diamond self mon process
-            {
-                'exe': 'DUMMY',
-                'name': 'DUMMY',
-                'pid': self.SELFMON_PID,
-                'rss': 1234,
-                'vms': 4,
-            },
-        ]
-
-        class ProcessMock:
-            def __init__(self, pid, name, rss, vms, exe=None):
-                self.pid = pid
-                self.name = name
-                self.rss = rss
-                self.vms = vms
-                if exe is not None:
-                    self.exe = exe
-
-                self.cmdline = [self.exe]
-                self.create_time = 0
-
-            def as_dict(self):
-                from collections import namedtuple
-                meminfo = namedtuple('meminfo', 'rss vms')
-                ext_meminfo = namedtuple('meminfo',
-                                         'rss vms shared text lib data dirty')
-                cputimes = namedtuple('cputimes', 'user system')
-                thread = namedtuple('thread', 'id user_time system_time')
-                user = namedtuple('user', 'real effective saved')
-                group = namedtuple('group', 'real effective saved')
-                ionice = namedtuple('ionice', 'ioclass value')
-                amount = namedtuple('amount', 'voluntary involuntary')
-                return {
-                    'status': 'sleeping',
-                    'num_ctx_switches': amount(voluntary=2243, involuntary=221),
-                    'pid': self.pid,
-                    'connections': None,
-                    'cmdline': [self.exe],
-                    'create_time': 0,
-                    'ionice': ionice(ioclass=0, value=0),
-                    'num_fds': 10,
-                    'memory_maps': None,
-                    'cpu_percent': 0.0,
-                    'terminal': None,
-                    'ppid': 0,
-                    'cwd': None,
-                    'nice': 0,
-                    'username': 'root',
-                    'cpu_times': cputimes(user=0.27, system=1.05),
-                    'io_counters': None,
-                    'ext_memory_info': ext_meminfo(rss=self.rss,
-                                                   vms=self.vms,
-                                                   shared=1310720,
-                                                   text=188416,
-                                                   lib=0,
-                                                   data=868352,
-                                                   dirty=0),
-                    'threads': [thread(id=1, user_time=0.27, system_time=1.04)],
-                    'open_files': None,
-                    'name': self.name,
-                    'num_threads': 1,
-                    'exe': self.exe,
-                    'uids': user(real=0, effective=0, saved=0),
-                    'gids': group(real=0, effective=0, saved=0),
-                    'cpu_affinity': [0, 1, 2, 3],
-                    'memory_percent': 0.03254831000922748,
-                    'memory_info': meminfo(rss=self.rss, vms=self.vms)}
-
         process_iter_mock = (ProcessMock(
             pid=x['pid'],
             name=x['name'],
             rss=x['rss'],
             vms=x['vms'],
             exe=x['exe'])
-            for x in process_info_list)
+            for x in self.PROCESS_INFO_LIST)
 
         time_mock.return_value = 1234567890
 
-        getpid_mock.return_value = self.SELFMON_PID
+        getpid_mock.return_value = SELFMON_PID
 
         patch_psutil_process_iter = patch('psutil.process_iter',
                                           return_value=process_iter_mock)
@@ -222,6 +163,65 @@ class TestProcessResourcesCollector(CollectorTestCase):
         self.assertPublished(publish_mock, 'barexe.ext_memory_info.rss', 3)
         self.assertPublished(publish_mock,
                              'diamond-selfmon.ext_memory_info.rss', 1234)
+
+class ProcessMock:
+    def __init__(self, pid, name, rss, vms, exe=None):
+        self.pid = pid
+        self.name = name
+        self.rss = rss
+        self.vms = vms
+        if exe is not None:
+            self.exe = exe
+
+        self.cmdline = [self.exe]
+        self.create_time = 0
+
+    def as_dict(self):
+        from collections import namedtuple
+        meminfo = namedtuple('meminfo', 'rss vms')
+        ext_meminfo = namedtuple('meminfo',
+                                 'rss vms shared text lib data dirty')
+        cputimes = namedtuple('cputimes', 'user system')
+        thread = namedtuple('thread', 'id user_time system_time')
+        user = namedtuple('user', 'real effective saved')
+        group = namedtuple('group', 'real effective saved')
+        ionice = namedtuple('ionice', 'ioclass value')
+        amount = namedtuple('amount', 'voluntary involuntary')
+        return {
+            'status': 'sleeping',
+            'num_ctx_switches': amount(voluntary=2243, involuntary=221),
+            'pid': self.pid,
+            'connections': None,
+            'cmdline': [self.exe],
+            'create_time': 0,
+            'ionice': ionice(ioclass=0, value=0),
+            'num_fds': 10,
+            'memory_maps': None,
+            'cpu_percent': 0.0,
+            'terminal': None,
+            'ppid': 0,
+            'cwd': None,
+            'nice': 0,
+            'username': 'root',
+            'cpu_times': cputimes(user=0.27, system=1.05),
+            'io_counters': None,
+            'ext_memory_info': ext_meminfo(rss=self.rss,
+                                           vms=self.vms,
+                                           shared=1310720,
+                                           text=188416,
+                                           lib=0,
+                                           data=868352,
+                                           dirty=0),
+            'threads': [thread(id=1, user_time=0.27, system_time=1.04)],
+            'open_files': None,
+            'name': self.name,
+            'num_threads': 1,
+            'exe': self.exe,
+            'uids': user(real=0, effective=0, saved=0),
+            'gids': group(real=0, effective=0, saved=0),
+            'cpu_affinity': [0, 1, 2, 3],
+            'memory_percent': 0.03254831000922748,
+            'memory_info': meminfo(rss=self.rss, vms=self.vms)}
 
 ################################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
psutil2 change the memory stat name from ext_memory_info to memory_info_ex.

The PR supports both names and includes a test.

A similar issue: #67
A similar PR: #53
