### PR TITLE
Add JolokiaBulkCollector to gather metrics using the bulk request syntax

### DIFF
--- a/src/collectors/jolokia/bulk_jolokia.py
+++ b/src/collectors/jolokia/bulk_jolokia.py
@@ -1,0 +1,117 @@
+# coding=utf-8
+
+"""
+ Collects JMX metrics from the Jolokia Agent. Jolokia is an HTTP bridge that
+provides access to JMX MBeans without the need to write Java code. See the
+[Reference Guide](http://www.jolokia.org/reference/html/index.html) for more
+information.
+
+The liste MBean patterns will be queried for metrics. All numerical values will
+be published to Graphite; anything else will be ignored.
+The JolokiaBulkCollector will create a reasonable namespace for each metric
+based on each MBeans domain and name.
+e.g) ```java.lang:name=ParNew,type=GarbageCollector``` would become
+```java.lang.name_ParNew.type_GarbageCollector```.
+
+#### Dependencies
+
+ * Jolokia
+ * A running JVM with Jolokia installed/configured
+
+#### Example Configuration
+
+JolokiaBulkCollector is configured to query specific MBeans by
+providing a list of ```mbeans```. The list of mbeans may include the
+wildcard '*' character, or any other valid Jolokia pattern
+(see https://jolokia.org/reference/html/protocol.html#read).
+
+The ```rewrite``` section provides a way of renaming the data keys before
+it sent out to the handler.  The section consists of pairs of from-to
+regular expressions.  If the resultant name is completely blank, the
+metric is not published, providing a way to exclude specific metrics within
+an mbean.
+
+```
+    host = localhost
+    port = 8778
+    mbeans = "java.lang:*,type=GarbageCollector",
+    [rewrite]
+    java = coffee
+    "-v\d+\.\d+\.\d+" = "-AllVersions"
+    ".*GetS2Activities.*" = ""
+```
+"""
+
+import base64
+import json
+import urllib
+import urllib2
+
+from jolokia import JolokiaCollector
+
+
+class JolokiaBulkCollector(JolokiaCollector):
+    # override to allow setting which percentiles will be collected
+    def get_default_config_help(self):
+        config_help = super(JolokiaBulkCollector,
+                            self).get_default_config_help()
+        config_help.update({
+            'mbeans': 'Comma separated list of mbean patterns to collect',
+        })
+        del config_help['regex']
+        return config_help
+
+    # override to allow setting which percentiles will be collected
+    def get_default_config(self):
+        config = super(JolokiaBulkCollector, self).get_default_config()
+        config.update({
+            'user': False,
+            'passwd': False,
+            'user-agent': False,
+        })
+        return config
+
+    def __init__(self, *args, **kwargs):
+        super(JolokiaBulkCollector, self).__init__(*args, **kwargs)
+
+    def collect(self):
+        requests = self.fetch_response()
+
+        for listing in requests:
+            if listing['status'] == 200:
+                domains = listing['value']
+                for domain in domains.keys():
+                    if domain not in self.IGNORE_DOMAINS:
+                        self.collect_bean(domain, domains[domain])
+            else:
+                logging.critical("%s(%s) : %s", listing['request'], listing['error_type'], listing['error'])
+
+    def fetch_response(self):
+        path = self.config['path']
+
+        if not(path.endswith('/')):
+            path = path + '/'
+
+        url = "http://%s:%s/%s?ignoreErrors=true" % (self.config['host'],
+                                                     self.config['port'],
+                                                     path)
+
+        data = []
+
+        for mbean in self.config['mbeans']:
+            data.append({'type': 'read', 'mbean': mbean})
+
+        headers = {'content-type': 'application/json'}
+
+        request = urllib2.Request(url, json.dumps(data), headers)
+
+        if self.config['user']:
+            base64string = base64.encodestring('%s:%s' % (
+                self.config['user'], self.config['passwd'])).replace('\n', '')
+            request.add_header("Authorization", "Basic %s" % base64string)
+
+        if self.config['user-agent']:
+            request.add_header("User-Agent", self.config['user-agent'])
+
+        response = urllib2.urlopen(request)
+        return self.read_json(response)

--- a/src/collectors/jolokia/test/fixtures/multiple_listings
+++ b/src/collectors/jolokia/test/fixtures/multiple_listings
@@ -1,0 +1,54 @@
+[{
+    "timestamp": 1406058643,
+    "status": 200,
+    "request": {
+        "mbean": "java.lang:*",
+        "type": "read"
+    },
+    "value": {
+        "java.lang:name=(ParNew):,type=GarbageCollector": {
+            "Name": "(ParNew)",
+            "LastGcInfo": {
+                "startTime": 14259063,
+                "id": 219,
+                "duration": 2,
+                "memoryUsageBeforeGc": {
+                    "Par Eden Space": {
+                        "max": 25165824,
+                        "committed": 25165824,
+                        "init": 25165824,
+                        "used": 25165824
+                    },
+                    "CMS Old Gen": {
+                        "max": 73400320,
+                        "committed": 73400320,
+                        "init": 73400320,
+                        "used": 5146840
+                    },
+                    "CMS Perm Gen": {
+                        "max": 85983232,
+                        "committed": 23920640,
+                        "init": 21757952,
+                        "used": 23796992
+                    },
+                    "Code Cache": {
+                        "max": 50331648,
+                        "committed": 2686976,
+                        "init": 2555904,
+                        "used": 2600768
+                    },
+                    "Par Survivor Space": {
+                        "max": 3145728,
+                        "committed": 3145728,
+                        "init": 3145728,
+                        "used": 414088
+                    }
+                },
+                "CollectionCount": 219,
+                "MemoryPoolNames": ["Par Eden Space", "Par Survivor Space"],
+                "Valid": true,
+                "CollectionTime": 497
+            }
+        }
+    }
+}]

--- a/src/collectors/jolokia/test/testbulk_jolokia.py
+++ b/src/collectors/jolokia/test/testbulk_jolokia.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import patch
+
+from diamond.collector import Collector
+
+from bulk_jolokia import JolokiaBulkCollector
+
+################################################################################
+
+
+class TestJolokiaBulkCollector(CollectorTestCase):
+    def setUp(self):
+        c = {'mbeans': ["java.lang:*,type=GarbageCollector"]}
+        config = get_collector_config('JolokiaBulkCollector', c)
+
+        self.collector = JolokiaBulkCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(JolokiaBulkCollector)
+
+    @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data(self, publish_mock):
+        def se(request):
+            assert request.get_full_url() == 'http://localhost:8778/jolokia'
+            return self.getFixture('multiple_listings')
+        patch_urlopen = patch('urllib2.urlopen', Mock(side_effect=se))
+
+        patch_urlopen.start()
+        self.collector.collect()
+        patch_urlopen.stop()
+
+        metrics = self.get_metrics()
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    def test_should_support_basic_auth(self):
+        def se(request):
+            assert request.has_header('Authorization')
+
+        patch_urlopen = patch('urllib2.urlopen', Mock(side_effect=se))
+
+        authn = {'user': 'x', 'passwd': 'y'}
+        config = get_collector_config('JolokiaBulkCollector', authn)
+        collector_with_auth = JolokiaBulkCollector(config, None)
+
+        patch_urlopen.start()
+        collector_with_auth.open_url("http://localhost:8778")
+        patch_urlopen.stop()
+
+    def test_should_support_setting_the_user_agent(self):
+        def se(request):
+            assert request.has_header('User-agent')
+            assert request.get_header('User-agent') == "curl/xyz"
+
+        patch_urlopen = patch('urllib2.urlopen', Mock(side_effect=se))
+
+        ua = {'user-agent': 'curl/xyz'}
+        config = get_collector_config('JolokiaBulkCollector', ua)
+        collector_with_ua = JolokiaBulkCollector(config, None)
+
+        patch_urlopen.start()
+        collector_with_ua.open_url("http://localhost:8778")
+        patch_urlopen.stop()
+
+    def get_metrics(self):
+        prefix = 'java.lang.name_ParNew.type_GarbageCollector.LastGcInfo'
+        return {
+            prefix + '.startTime': 14259063,
+            prefix + '.id': 219,
+            prefix + '.duration': 2,
+            prefix + '.memoryUsageBeforeGc.Par_Eden_Space.max': 25165824,
+            prefix + '.memoryUsageBeforeGc.Par_Eden_Space.committed': 25165824,
+            prefix + '.memoryUsageBeforeGc.Par_Eden_Space.init': 25165824,
+            prefix + '.memoryUsageBeforeGc.Par_Eden_Space.used': 25165824,
+            prefix + '.memoryUsageBeforeGc.CMS_Old_Gen.max': 73400320,
+            prefix + '.memoryUsageBeforeGc.CMS_Old_Gen.committed': 73400320,
+            prefix + '.memoryUsageBeforeGc.CMS_Old_Gen.init': 73400320,
+            prefix + '.memoryUsageBeforeGc.CMS_Old_Gen.used': 5146840,
+            prefix + '.memoryUsageBeforeGc.CMS_Perm_Gen.max': 85983232,
+            prefix + '.memoryUsageBeforeGc.CMS_Perm_Gen.committed': 23920640,
+            prefix + '.memoryUsageBeforeGc.CMS_Perm_Gen.init': 21757952,
+            prefix + '.memoryUsageBeforeGc.CMS_Perm_Gen.used': 23796992,
+            prefix + '.memoryUsageBeforeGc.Code_Cache.max': 50331648,
+            prefix + '.memoryUsageBeforeGc.Code_Cache.committed': 2686976,
+            prefix + '.memoryUsageBeforeGc.Code_Cache.init': 2555904,
+            prefix + '.memoryUsageBeforeGc.Code_Cache.used': 2600768,
+            prefix + '.memoryUsageBeforeGc.Par_Survivor_Space.max': 3145728,
+            prefix + '.memoryUsageBeforeGc.Par_Survivor_Space.committed':
+            3145728,
+            prefix + '.memoryUsageBeforeGc.Par_Survivor_Space.init': 3145728,
+            prefix + '.memoryUsageBeforeGc.Par_Survivor_Space.used': 414088
+        }
+
+################################################################################
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The `JolokiaBulkCollector` uses Jolokia's bulk request syntax [1] to optimize retrieving values from many mbeans. As of Jolokia 1.2.2 (and possibly earlier..), mbeans can be listed using wildcards and, with the bulk request api, can be retrieved directly. 

With the `JolokiaCollector`, when collecting metrics from JVMs with many mbeans, often the collector will hit the timeout while trying to process each mbean (even for generous intervals in excess of 300s). With the bulk collector, the collector is able to retrieve multiple mbean metrics without incurring the same overhead as many individual requests, and is able to finish running in <10s.

This initial work does not implement the mbean regex feature, and requires that all mbeans be explicitly listed (possibly using Jolokia's wildcard syntax). I suspect they could be readded in the future, if desirable. 

This also includes #177, but could be trivially refactored to be stand-alone.

[1] https://jolokia.org/reference/html/protocol.html#post-request
