### PR TITLE
Fix import statement

### DIFF
--- a/src/diamond/handler/influxdbHandler.py
+++ b/src/diamond/handler/influxdbHandler.py
@@ -35,7 +35,7 @@ import time
 from Handler import Handler
 
 try:
-    from influxdb.client import InfluxDBClient
+    from influxdb.influxdb08 import InfluxDBClient
 except ImportError:
     InfluxDBClient = None
 


### PR DESCRIPTION
It needs to change import statement because currently influxdb-python modules uses 0.9.x api based client by default.
https://github.com/influxdb/influxdb-python#influxdb-v08x-users