### PR TITLE
updated elasticsearch.py collector for alias stats

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -24,8 +24,6 @@ except ImportError:
 
 import diamond.collector
 
-RE_LOGSTASH_INDEX = re.compile('^(.*)-\d\d\d\d\.\d\d\.\d\d$')
-
 
 class ElasticSearchCollector(diamond.collector.Collector):
 
@@ -57,7 +55,9 @@ class ElasticSearchCollector(diamond.collector.Collector):
                 port = 9200
 
             self.instances[alias] = (host, int(port))
-
+        
+        self.re_logstash_filter = re.compile(self.config['logstash_filter'])
+            
     def get_default_config_help(self):
         config_help = super(ElasticSearchCollector,
                             self).get_default_config_help()
@@ -75,6 +75,9 @@ class ElasticSearchCollector(diamond.collector.Collector):
             + "the YYYY.MM.DD suffix from the index name "
             + "(e.g. logstash-adm-syslog-2014.01.03) and use that "
             + "as a bucket for all 'day' index stats.",
+            'logstash_filter': "regular expression to strip the date "
+            + "from the index name. Default to "
+            + "'^(.*)-\d\d\d\d\.\d\d\.\d\d$'",
         })
         return config_help
 
@@ -90,6 +93,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
             'path':           'elasticsearch',
             'stats':          ['jvm', 'thread_pool', 'indices'],
             'logstash_mode': False,
+            'logstash_filter': '^(.*)-\d\d\d\d\.\d\d\.\d\d$',
             'cluster':       False,
         })
         return config
@@ -134,7 +138,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
             """Remove the YYYY.MM.DD bit from logstash indices.
             This way we keep using the same metric naming and not polute
             our metrics system (e.g. Graphite) with new metrics every day."""
-            m = RE_LOGSTASH_INDEX.match(prefix)
+            m = self.re_logstash_filter.match(prefix)
             if m:
                 prefix = m.group(1)
 


### PR DESCRIPTION
This PR allows the user to change the Logstash regular expression in the config file.
While logstash always use the same regexp, some applications don't.

Default regexp is still the original logstash one...