### PR TITLE
Changed to use the influxdb08 compatible module

### DIFF
--- a/src/diamond/handler/influxdbHandler.py
+++ b/src/diamond/handler/influxdbHandler.py
@@ -35,7 +35,7 @@ import time
 from Handler import Handler
 
 try:
-    from influxdb.client import InfluxDBClient
+    from influxdb.influxdb08.client import InfluxDBClient
 except ImportError:
     InfluxDBClient = None
 


### PR DESCRIPTION
The latest version of influxdb python client does not work currently. This just sets it to use the v0.8x compatible module. influxdb 0.9x support should ideally be put in to a new module.