### PR TITLE
Update AWS CloudWatch handler to use the proper dimension name

### DIFF
--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -2,7 +2,7 @@
 """
 Output the collected values to AWS CloudWatch
 
-Automatically adds the InstanceID Dimension
+Automatically adds the InstanceId Dimension
 
 #### Dependencies
 
@@ -77,7 +77,7 @@ class cloudwatchHandler(Handler):
             self.log.error('CloudWatch: Failed to load instance metadata')
             return
         self.instance_id = instances['instance-id']
-        self.log.debug("Setting InstanceID: " + self.instance_id)
+        self.log.debug("Setting InstanceId: " + self.instance_id)
 
         self.valid_config = ('region', 'collector', 'metric', 'namespace',
                              'name', 'unit')
@@ -197,7 +197,7 @@ class cloudwatchHandler(Handler):
                         str(rule['name']),
                         str(metric.value),
                         timestamp, str(rule['unit']),
-                        {'InstanceID': self.instance_id})
+                        {'InstanceId': self.instance_id})
                     self.log.debug(
                         "CloudWatch: Successfully published metric: %s to"
                         " %s with value (%s)",


### PR DESCRIPTION
The CloudWatch handler sets the instance dimension name to "InstanceID", AWS however specify their default metrics with the name "InstanceId", which is also is the expected casing used elsewhere as well withing AWS. The Diamond CloudWatch handler should obey this naming convention to allow metrics to be published within the same dimension as e.g. the default AWS EC2 metrics (CPUUtilization, DiskReadBytes etc).

It would make it more coherent when e.g. configuring CloudWatch alarms through Cloudformation when the same dimension name "InstanceId" could be used for all metrics, instead of needing to know that Diamond pushed metrics use another case than the AWS ones. 