### PR TITLE
bugfix: type error on values = []

### DIFF
--- a/src/collectors/httpjson/httpjson.py
+++ b/src/collectors/httpjson/httpjson.py
@@ -43,7 +43,7 @@ class HTTPJSONCollector(diamond.collector.Collector):
             else:
                 try:
                     int(value)
-                except ValueError:
+                except (ValueError, TypeError):
                     value = None
                 finally:
                     yield ("%s.%s" % (prefix, key), value)


### PR DESCRIPTION
Fix in HTTPJSONCollector
When one of a key values is a list, the collector fails silently with:
TypeError: int() argument must be a string or a number, not 'list'
