### PR TITLE
add multicollector support based on whitespace and dot split

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -161,10 +161,11 @@ class Server(object):
                 )
 
                 for process_name in running_collectors - running_processes:
-                    # To handle running multiple collectors concurrently, we
-                    # split on white space and use the first word as the
-                    # collector name to spin
+                    # To handle running multiple collectors concurrently, fist
+                    # we split on white space, then on dot and use the first
+                    # word as the collector name to spin.
                     collector_name = process_name.split()[0]
+                    collector_name = collector_name.split('.', 1)[0]
 
                     if 'Collector' not in collector_name:
                         continue


### PR DESCRIPTION
Currently diamond is able to create multiple instances per collector class by loading config files with the format  `CollectorClassName instance.conf`, in my opinion I think is better if it can support also dots as separator to make it easy for shell scripts, provisioning tools, and also for some people (like me :-). What do do think?

If the patch is accepted I will create a record in the FAQ.md explaining those options to get them documented.
