### PR TITLE
mongodb: collect Mongo replSet status

### DIFF
--- a/src/collectors/mongodb/mongodb.py
+++ b/src/collectors/mongodb/mongodb.py
@@ -4,6 +4,10 @@
 Collects all number values from the db.serverStatus() command, other
 values are ignored.
 
+**Note:** this collector expects pymongo 2.4 and onward. See the pymongo
+changelog for more details:
+http://api.mongodb.org/python/current/changelog.html#changes-in-version-2-4
+
 #### Dependencies
 
  * pymongo

--- a/src/collectors/mongodb/mongodb.py
+++ b/src/collectors/mongodb/mongodb.py
@@ -59,13 +59,17 @@ class MongoDBCollector(diamond.collector.Collector):
             'of collections. This is applied after collections are ignored via'
             ' ignore_collections Sampling uses crc32 so it is consistent across'
             ' replicas. Value between 0 and 1. Default is 1',
-            'network_timeout': 'Timeout for mongodb connection (in seconds).'
-                               ' There is no timeout by default.',
+            'network_timeout': 'Timeout for mongodb connection (in'
+                               ' milliseconds). There is no timeout by'
+                               ' default.',
             'simple': 'Only collect the same metrics as mongostat.',
             'translate_collections': 'Translate dot (.) to underscores (_)'
                                      ' in collection names.',
             'ssl': 'True to enable SSL connections to the MongoDB server.'
-                    ' Default is False'
+                    ' Default is False',
+            'replica': 'True to enable replica set logging. Reports health of'
+                       ' individual nodes as well as basic aggregate stats.'
+                       ' Default is False'
         })
         return config_help
 
@@ -85,7 +89,8 @@ class MongoDBCollector(diamond.collector.Collector):
             'simple': 'False',
             'translate_collections': 'False',
             'collection_sample_rate': 1,
-            'ssl': False
+            'ssl': False,
+            'replica': False
         })
         return config
 
@@ -147,16 +152,15 @@ class MongoDBCollector(diamond.collector.Collector):
                     self.config['ssl'] = str_to_bool(self.config['ssl'])
 
                 if ReadPreference is None:
-                    conn = pymongo.Connection(
+                    conn = pymongo.MongoClient(
                         host,
-                        network_timeout=self.config['network_timeout'],
+                        socketTimeoutMS=self.config['network_timeout'],
                         ssl=self.config['ssl'],
-                        slave_okay=True
                     )
                 else:
-                    conn = pymongo.Connection(
+                    conn = pymongo.MongoClient(
                         host,
-                        network_timeout=self.config['network_timeout'],
+                        socketTimeoutMS=self.config['network_timeout'],
                         ssl=self.config['ssl'],
                         read_preference=ReadPreference.SECONDARY,
                     )
@@ -177,6 +181,13 @@ class MongoDBCollector(diamond.collector.Collector):
             self._publish_transformed(data, base_prefix)
             if str_to_bool(self.config['simple']):
                 data = self._extract_simple_data(data)
+            if str_to_bool(self.config['replica']):
+                try:
+                    replset_data = conn.admin.command('replSetGetStatus')
+                    self._publish_replset(replset_data, base_prefix)
+                except pymongo.errors.OperationFailure as e:
+                    self.log.error('error getting replica set status', e)
+            self._publish_transformed(data, base_prefix)
 
             self._publish_dict_with_prefix(data, base_prefix)
             db_name_filter = re.compile(self.config['databases'])
@@ -204,6 +215,25 @@ class MongoDBCollector(diamond.collector.Collector):
                     collection_prefix = db_prefix + [collection_name]
                     self._publish_dict_with_prefix(collection_stats,
                                                    collection_prefix)
+
+    def _publish_replset(self, data, base_prefix):
+        """ Given a response to replSetGetStatus, publishes all numeric values
+            of the instance, aggregate stats of healthy nodes vs total nodes,
+            and the observed statuses of all nodes in the replica set.
+        """
+        prefix = base_prefix + ['replset']
+        self._publish_dict_with_prefix(data, prefix)
+        total_nodes = len(data['members'])
+        healthy_nodes = reduce(lambda value, node: value + node['health'],
+                               data['members'], 0)
+
+        self._publish_dict_with_prefix({
+            'healthy_nodes': healthy_nodes,
+            'total_nodes': total_nodes
+            }, prefix)
+        for node in data['members']:
+            self._publish_dict_with_prefix(node,
+                                           prefix + ['node', str(node['_id'])])
 
     def _publish_transformed(self, data, base_prefix):
         """ Publish values of type: counter or percent """

--- a/src/collectors/mongodb/test/testmongodb.py
+++ b/src/collectors/mongodb/test/testmongodb.py
@@ -29,7 +29,7 @@ class TestMongoDBCollector(CollectorTestCase):
     def setUp(self):
         config = get_collector_config('MongoDBCollector', {
             'host': 'localhost:27017',
-            'databases': '^db',
+            'databases': '^db'
         })
         self.collector = MongoDBCollector(config, None)
         self.connection = MagicMock()
@@ -38,7 +38,7 @@ class TestMongoDBCollector(CollectorTestCase):
         self.assertTrue(MongoDBCollector)
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_publish_nested_keys_for_server_stats(self,
                                                          publish_mock,
@@ -55,7 +55,7 @@ class TestMongoDBCollector(CollectorTestCase):
         })
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_publish_nested_keys_for_db_stats(self,
                                                      publish_mock,
@@ -77,7 +77,7 @@ class TestMongoDBCollector(CollectorTestCase):
         self.assertPublishedMany(publish_mock, metrics)
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_publish_stats_with_long_type(self,
                                                  publish_mock,
@@ -94,7 +94,7 @@ class TestMongoDBCollector(CollectorTestCase):
         })
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_ignore_unneeded_databases(self,
                                               publish_mock,
@@ -106,7 +106,7 @@ class TestMongoDBCollector(CollectorTestCase):
         assert call('baddb') not in self.connection.__getitem__.call_args_list
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_ignore_unneeded_collections(self,
                                                 publish_mock,
@@ -133,6 +133,19 @@ class TestMongoDBCollector(CollectorTestCase):
 
         self.assertPublishedMany(publish_mock, metrics)
 
+    @run_only_if_pymongo_is_available
+    @patch('pymongo.MongoClient')
+    @patch.object(Collector, 'publish')
+    def test_should_ignore_replset_status_if_disabled(self,
+                                                      publish_mock,
+                                                      connector_mock):
+        data = {'more_keys': long(1), 'key': 2, 'string': 'str'}
+        self._annotate_connection(connector_mock, data)
+
+        self.collector.collect()
+        assert call('replsetSetGetStatus') not in \
+            self.connection.admin.command.method_calls
+
     def _annotate_connection(self, connector_mock, data):
         connector_mock.return_value = self.connection
         self.connection.db.command.return_value = data
@@ -152,7 +165,7 @@ class TestMongoMultiHostDBCollector(CollectorTestCase):
         self.assertTrue(MongoDBCollector)
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_publish_nested_keys_for_server_stats(self,
                                                          publish_mock,
@@ -171,7 +184,7 @@ class TestMongoMultiHostDBCollector(CollectorTestCase):
         })
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_publish_nested_keys_for_db_stats(self,
                                                      publish_mock,
@@ -195,7 +208,7 @@ class TestMongoMultiHostDBCollector(CollectorTestCase):
         self.assertPublishedMany(publish_mock, metrics)
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_publish_stats_with_long_type(self,
                                                  publish_mock,
@@ -214,7 +227,7 @@ class TestMongoMultiHostDBCollector(CollectorTestCase):
         })
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_ignore_unneeded_databases(self,
                                               publish_mock,
@@ -226,7 +239,7 @@ class TestMongoMultiHostDBCollector(CollectorTestCase):
         assert call('baddb') not in self.connection.__getitem__.call_args_list
 
     @run_only_if_pymongo_is_available
-    @patch('pymongo.Connection')
+    @patch('pymongo.MongoClient')
     @patch.object(Collector, 'publish')
     def test_should_ignore_unneeded_collections(self,
                                                 publish_mock,
@@ -253,6 +266,39 @@ class TestMongoMultiHostDBCollector(CollectorTestCase):
         }
 
         self.assertPublishedMany(publish_mock, metrics)
+
+    def _annotate_connection(self, connector_mock, data):
+        connector_mock.return_value = self.connection
+        self.connection.db.command.return_value = data
+        self.connection.database_names.return_value = ['db1', 'baddb']
+
+
+class TestMongoDBCollectorWithReplica(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('MongoDBCollector', {
+            'host': 'localhost:27017',
+            'databases': '^db',
+            'replica': True
+        })
+        self.collector = MongoDBCollector(config, None)
+        self.connection = MagicMock()
+
+    def test_import(self):
+        self.assertTrue(MongoDBCollector)
+
+    @run_only_if_pymongo_is_available
+    @patch('pymongo.MongoClient')
+    @patch.object(Collector, 'publish')
+    def test_should_publish_replset_status_if_enabled(self,
+                                                      publish_mock,
+                                                      connector_mock):
+        data = {'more_keys': long(1), 'key': 2, 'string': 'str'}
+        self._annotate_connection(connector_mock, data)
+
+        self.collector.collect()
+
+        self.connection.admin.command.assert_called_once_with(
+            'replSetGetStatus')
 
     def _annotate_connection(self, connector_mock, data):
         connector_mock.return_value = self.connection


### PR DESCRIPTION
Fetches Mongodb replica set stats by calling [replSetGetStatus](http://docs.mongodb.org/manual/reference/command/replSetGetStatus/). Also publishes keys `healthy_nodes` and `total_nodes` as a summary of the per-node data.

This can be enabled by setting "replica" in the config.