### PR TITLE
Fix for #241 (Log file permissions world-writable)

### DIFF
--- a/bin/diamond
+++ b/bin/diamond
@@ -236,7 +236,7 @@ def main():
                     sys.exit(1)
                 # Decouple from parent environmen
                 os.setsid()
-                os.umask(0)
+                os.umask(0o022)
                 # Fork 2
                 try:
                     pid = os.fork()


### PR DESCRIPTION
Sets umask to 022 instead of 000, to avoid creating new files as world-writable.