### PR TITLE
DiskSpace : Add nfs4 as default FS to monitor

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -51,8 +51,8 @@ class DiskSpaceCollector(diamond.collector.Collector):
         config.update({
             'path': 'diskspace',
             # filesystems to examine
-            'filesystems': 'ext2, ext3, ext4, xfs, glusterfs, nfs, ntfs, hfs,'
-            + ' fat32, fat16, btrfs',
+            'filesystems': 'ext2, ext3, ext4, xfs, glusterfs, nfs, nfs4, ntfs,'
+            + ' hfs, fat32, fat16, btrfs',
 
             # exclude_filters
             #   A list of regex patterns


### PR DESCRIPTION
On debian based distributions nfs is often called nfs4 , it might be a good idea to add in the default list ...
