### PR TITLE
Ignore per project pyenv settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ src/*.egg-info
 .tox
 gentoo/diamond-*.ebuild
 .vagrant
+.python-version


### PR DESCRIPTION
When using pyenv, it's useful to set the python version for the project itself. This just ignores the dot file that is stored in the root of the project directory.