### PR TITLE
Fix collectors to support sub-second collection intervals

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -441,7 +441,7 @@ class Collector(object):
 
             # If we pass in a interval, use it rather then the configured one
             if interval is None:
-                interval = int(self.config['interval'])
+                interval = float(self.config['interval'])
 
             # Get Change in Y (time)
             if time_delta:


### PR DESCRIPTION
When testing collectors, some times it best to collect at a very rapid speed. The collector module attempts to cast the interval as an int rather then as a float and throws an exception. This fixes that