### PR TITLE
Prevent Diamond from hemorrhaging memory

### DIFF
--- a/src/diamond/metric.py
+++ b/src/diamond/metric.py
@@ -7,8 +7,14 @@ from error import DiamondException
 
 
 class Metric(object):
-
-    _METRIC_TYPES = ['COUNTER', 'GAUGE']
+    # This saves a significant amount of memory per object. This only matters
+    # due to the queue system that moves objects between processes and can end
+    # up storing a large number of objects in the queue waiting for the
+    # handlers to flush.
+    __slots__ = [
+        'path', 'value', 'raw_value', 'timestamp', 'precision',
+        'host', 'metric_type', 'ttl'
+        ]
 
     def __init__(self, path, value, raw_value=None, timestamp=None, precision=0,
                  host=None, metric_type='COUNTER', ttl=None):
@@ -24,7 +30,7 @@ class Metric(object):
         """
 
         # Validate the path, value and metric_type submitted
-        if (None in [path, value] or metric_type not in self._METRIC_TYPES):
+        if (None in [path, value] or metric_type not in ['COUNTER', 'GAUGE']):
             raise DiamondException(("Invalid parameter when creating new "
                                     "Metric with path: %r value: %r "
                                     "metric_type: %r")
@@ -78,6 +84,17 @@ class Metric(object):
 
         # Return formated string
         return fstring % (self.path, self.value, self.timestamp)
+
+    def __getstate__(self):
+        return dict(
+            (slot, getattr(self, slot))
+            for slot in self.__slots__
+            if hasattr(self, slot)
+        )
+
+    def __setstate__(self, state):
+        for slot, value in state.items():
+            setattr(self, slot, value)
 
     @classmethod
     def parse(cls, string):

--- a/src/diamond/metric.py
+++ b/src/diamond/metric.py
@@ -30,7 +30,7 @@ class Metric(object):
         """
 
         # Validate the path, value and metric_type submitted
-        if (None in [path, value] or metric_type not in ['COUNTER', 'GAUGE']):
+        if (None in [path, value] or metric_type not in ('COUNTER', 'GAUGE')):
             raise DiamondException(("Invalid parameter when creating new "
                                     "Metric with path: %r value: %r "
                                     "metric_type: %r")

--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -58,7 +58,7 @@ class Server(object):
         self.manager = multiprocessing.Manager()
         if setproctitle:
             setproctitle(oldproctitle)
-        self.metric_queue = self.manager.Queue()
+        self.metric_queue = self.manager.Queue(maxsize=16384)
 
     def run(self):
         """

--- a/src/diamond/utils/scheduler.py
+++ b/src/diamond/utils/scheduler.py
@@ -108,10 +108,9 @@ def handler_process(handlers, metric_queue, log):
     log.debug('Starting process %s', proc.name)
 
     while(True):
-        metrics = metric_queue.get(block=True, timeout=None)
-        for metric in metrics:
-            for handler in handlers:
-                handler._process(metric)
-
+        metric = metric_queue.get(block=True, timeout=None)
         for handler in handlers:
-            handler._flush()
+            if metric is not None:
+                handler._process(metric)
+            else:
+                handler._flush()


### PR DESCRIPTION
Diamond uses a unbounded queue to send metrics to the handler process When a handler stalls due to a connection attempt or similar, this causes the queue process to just grow until we run out of memory. This change does a few things.

1. Brounds the queue to 16k unprocessed metrics before dropping them
2. Removes a unneeded array and just sends the metrics directly down the queue directly rather then wrapping them in a list
3. Uses a None object as a flush indicator
4. Moves to __slots__ for the Metric object. This reduces the memory of the Metrics significantly
5. Adds methods to the Metric object to allow pickling/unpickling if ever needed

In my tests, this reduces the memory cost of 2048 Metric objects from ~35M to ~2M

This should fix #84 and even reduce the latency for the metrics being published.