### PR TITLE
Set groups when changing `uid` and `gid` since Python doesn't do it.

### DIFF
--- a/bin/diamond
+++ b/bin/diamond
@@ -198,6 +198,10 @@ def main():
         if not options.skip_change_user:
             # Switch user to specified user/group if required
             try:
+                if gid != -1 and uid != -1:
+                    # Manually set the groups since they aren't set by default
+                    os.initgroups(pwd.getpwuid(uid).pw_name, gid)
+
                 if gid != -1 and os.getgid() != gid:
                     # Set GID
                     os.setgid(gid)


### PR DESCRIPTION
This fixes Diamond not being able to make use of group permissions on
files when the user is switched.

According to Python issue:
http://bugs.python.org/issue10032

The groups need to be manually set when changing the `uid`/`gid`
manually.