### PR TITLE
Use psutil.virtual_memory and swap_memory to collect memory usage

### DIFF
--- a/src/collectors/memory/memory.py
+++ b/src/collectors/memory/memory.py
@@ -103,8 +103,14 @@ class MemoryCollector(diamond.collector.Collector):
                 self.log.error('No memory metrics retrieved')
                 return None
 
-            phymem_usage = psutil.phymem_usage()
-            virtmem_usage = psutil.virtmem_usage()
+            # psutil.phymem_usage() and psutil.virtmem_usage() are deprecated.
+            if hasattr(psutil, "phymem_usage"):
+                phymem_usage = psutil.phymem_usage()
+                virtmem_usage = psutil.virtmem_usage()
+            else:
+                phymem_usage = psutil.virtual_memory()
+                virtmem_usage = psutil.swap_memory()
+
             units = 'B'
 
             for unit in self.config['byte_unit']:


### PR DESCRIPTION
Use psutil.virtual_memory() and psutil.swap_memory() to monitor the actual memory usage

psutil.phymem_usage() and psutil.virtmem_usage() are deprecated.
Instead we now have psutil.virtual_memory() and psutil.swap_memory(),
which should provide all the necessary pieces to monitor the actual
system memory usage, both physical and swap/disk related.