### PR TITLE
Ensure Solr URLs don't have multiple '/'s

### DIFF
--- a/src/collectors/solr/solr.py
+++ b/src/collectors/solr/solr.py
@@ -24,6 +24,10 @@ import diamond.collector
 
 class SolrCollector(diamond.collector.Collector):
 
+    def __init__(self, *args, **kwargs):
+        super(SolrCollector, self).__init__(*args, ** kwargs)
+        self.config['host'] = self.config['host'].rstrip('/')
+
     def get_default_config_help(self):
         config_help = super(SolrCollector, self).get_default_config_help()
         config_help.update({
@@ -67,6 +71,7 @@ class SolrCollector(diamond.collector.Collector):
             return value
 
     def _get(self, path):
+        path = path.lstrip('/')
         url = 'http://%s:%i/%s' % (
             self.config['host'], int(self.config['port']), path)
         try:

--- a/src/collectors/solr/test/testsolr.py
+++ b/src/collectors/solr/test/testsolr.py
@@ -5,8 +5,7 @@
 from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
-from mock import Mock
-from mock import patch
+from mock import call, patch
 
 from diamond.collector import Collector
 
@@ -24,18 +23,16 @@ class TestSolrCollector(CollectorTestCase):
     def test_import(self):
         self.assertTrue(SolrCollector)
 
+    @patch('urllib2.urlopen')
     @patch.object(Collector, 'publish')
-    def test_should_work_with_real_data(self, publish_mock):
+    def test_should_work_with_real_data(self, publish_mock, urlopen_mock):
         returns = [self.getFixture('cores'),
                    self.getFixture('ping'),
                    self.getFixture('stats'),
                    self.getFixture('system')]
-        urlopen_mock = patch('urllib2.urlopen', Mock(
-            side_effect=lambda *args: returns.pop(0)))
+        urlopen_mock.side_effect = lambda *args: returns.pop(0)
 
-        urlopen_mock.start()
         self.collector.collect()
-        urlopen_mock.stop()
 
         metrics = {
             'response.QueryTime': 5,
@@ -130,16 +127,25 @@ class TestSolrCollector(CollectorTestCase):
                            metrics=metrics)
         self.assertPublishedMany(publish_mock, metrics)
 
-    @patch.object(Collector, 'publish')
-    def test_should_fail_gracefully(self, publish_mock):
-        urlopen_mock = patch('urllib2.urlopen', Mock(
-                             return_value=self.getFixture('stats_blank')))
+        urlopen_mock.assert_has_calls([
+            call(
+                'http://localhost:8983/solr/admin/cores?action=STATUS&wt=json'),
+            call('http://localhost:8983/solr/admin/ping?wt=json'),
+            call('http://localhost:8983/solr/admin/mbeans?stats=true&wt=json'),
+            call('http://localhost:8983/solr/admin/system?stats=true&wt=json')
+        ])
 
-        urlopen_mock.start()
+    @patch('urllib2.urlopen')
+    @patch.object(Collector, 'publish')
+    def test_should_fail_gracefully(self, publish_mock, urlopen_mock):
+        urlopen_mock.return_value = self.getFixture('stats_blank')
+
         self.collector.collect()
-        urlopen_mock.stop()
 
         self.assertPublishedMany(publish_mock, {})
+        urlopen_mock.assert_called_once_with(
+            'http://localhost:8983/solr/admin/cores?action=STATUS&wt=json')
+
 
 ##########################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
The URL formatting generally calls URLs with multiple forward slashes,
since the formatting includes a slash between host:port and path, while
the majority of the calls to `_get` also begin with forward slashes.

This can raise issues on some web servers.