### PR TITLE
Tweaks to ProcessResources Collector

### DIFF
--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -197,9 +197,12 @@ class ProcessResourcesCollector(diamond.collector.Collector):
 
         # publish results
         for pg_name, counters in self.processes_info.iteritems():
-            metrics = (
-                ("%s.%s" % (pg_name, key), value)
-                for key, value in counters.iteritems())
+            if counters:
+                metrics = (
+                    ("%s.%s" % (pg_name, key), value)
+                    for key, value in counters.iteritems())
+            else:
+                metrics = (("%s.%s" % (pg_name, key), -1) for key in self.default_info_keys)
             [self.publish(*metric) for metric in metrics]
             # reinitialize process info
             self.processes_info[pg_name] = {}

--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -32,6 +32,7 @@ import os
 import re
 import time
 import configobj
+import itertools
 
 import diamond.collector
 import diamond.convertor
@@ -214,8 +215,11 @@ class ProcessResourcesCollector(diamond.collector.Collector):
                     ("%s.%s" % (pg_name, key), value)
                     for key, value in counters.iteritems())
             else:
-                metrics = (("%s.%s" % (pg_name, key), -1)
-                           for key in self.default_info_keys)
+                metrics = [("%s.%s" % (pg_name, key), -1)
+                           for key in self.default_info_keys]
+                if cfg['count_workers']:
+                    metrics.append(('%s.workers_count' % pg_name: -1))
+
             [self.publish(*metric) for metric in metrics]
             # reinitialize process info
             self.processes_info[pg_name] = {}

--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -31,6 +31,7 @@ for example: cgi workers.
 import os
 import re
 import time
+import configobj
 
 import diamond.collector
 import diamond.convertor
@@ -105,6 +106,16 @@ class ProcessResourcesCollector(diamond.collector.Collector):
             count_workers: [boolean]
         }
         """
+        if 'path' in self.config['process']:
+            config_extension = self.config['process'].get('extension', '.conf')
+            for cfgfile in os.listdir(self.config['process']['path']):
+                cfgfile = os.path.join(self.config['process']['path'], cfgfile)
+                cfgfile = os.path.abspath(cfgfile)
+                if not cfgfile.endswith(config_extension):
+                    continue
+                newconfig = configobj.ConfigObj(cfgfile)
+                self.config.merge(newconfig)
+        [self.config['process'].pop(item, None) for item in ['path', 'extension']]
         self.processes = {}
         self.processes_info = {}
         for pg_name, cfg in self.config['process'].items():

--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -115,7 +115,8 @@ class ProcessResourcesCollector(diamond.collector.Collector):
                     continue
                 newconfig = configobj.ConfigObj(cfgfile)
                 self.config.merge(newconfig)
-        [self.config['process'].pop(item, None) for item in ['path', 'extension']]
+        [self.config['process'].pop(item, None)
+            for item in ['path', 'extension']]
         self.processes = {}
         self.processes_info = {}
         for pg_name, cfg in self.config['process'].items():
@@ -213,7 +214,8 @@ class ProcessResourcesCollector(diamond.collector.Collector):
                     ("%s.%s" % (pg_name, key), value)
                     for key, value in counters.iteritems())
             else:
-                metrics = (("%s.%s" % (pg_name, key), -1) for key in self.default_info_keys)
+                metrics = (("%s.%s" % (pg_name, key), -1)
+                           for key in self.default_info_keys)
             [self.publish(*metric) for metric in metrics]
             # reinitialize process info
             self.processes_info[pg_name] = {}


### PR DESCRIPTION
This PR allows to split the configuration of this collector into separate files. This is convenient for environments managed by orchestration tools, where different services may want to plug themselves in to this collector.

This also allows to send the -1 value for the collector metrics when the collected process is not found, this makes it possible to detect dead services.