### PR TITLE
Tweaks to ProcessResources Collector

### DIFF
--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -197,9 +197,16 @@ class ProcessResourcesCollector(diamond.collector.Collector):
 
         # publish results
         for pg_name, counters in self.processes_info.iteritems():
-            metrics = (
-                ("%s.%s" % (pg_name, key), value)
-                for key, value in counters.iteritems())
+            if counters:
+                metrics = (
+                    ("%s.%s" % (pg_name, key), value)
+                    for key, value in counters.iteritems())
+            else:
+                if self.processes[pg_name]['count_workers']:
+                    metrics = (('%s.workers_count' % pg_name, 0), )
+                else:
+                    metrics = ()
+
             [self.publish(*metric) for metric in metrics]
             # reinitialize process info
             self.processes_info[pg_name] = {}

--- a/src/collectors/processresources/test/testprocessresources.py
+++ b/src/collectors/processresources/test/testprocessresources.py
@@ -41,6 +41,10 @@ class TestProcessResourcesCollector(CollectorTestCase):
             'barexe': {
                 'exe': 'bar$'
             },
+            'noprocess': {
+                'name': 'noproc',
+                'count_workers': 'true'
+            },
             'diamond-selfmon': {
                 'selfmon': 'true',
             }
@@ -223,6 +227,8 @@ class TestProcessResourcesCollector(CollectorTestCase):
         self.assertPublished(publish_mock, 'barexe.ext_memory_info.rss', 3)
         self.assertPublished(publish_mock,
                              'diamond-selfmon.ext_memory_info.rss', 1234)
+        self.assertPublished(publish_mock, 'noprocess.workers_count', 0)
+        self.assertUnpublished(publish_mock, 'noprocess.uptime', 0)
 
 ##########################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
This PR allows to split the configuration of this collector into separate files. This is convenient for environments managed by orchestration tools, where different services may want to plug themselves in to this collector.

This also allows to send the -1 value for the collector metrics when the collected process is not found, this makes it possible to detect dead services.