### PR TITLE
Don't check values when checking unpublised metric

### DIFF
--- a/test.py
+++ b/test.py
@@ -195,24 +195,25 @@ class CollectorTestCase(unittest.TestCase):
 
         self.assertEqual(actual_value, expected_value, message)
 
-        actual_value = calls[0][0][0].value
-        expected_value = value
-        precision = 0
+        if expected_value:
+            actual_value = calls[0][0][0].value
+            expected_value = value
+            precision = 0
 
-        if isinstance(value, tuple):
-            expected_value, precision = expected_value
+            if isinstance(value, tuple):
+                expected_value, precision = expected_value
 
-        message = '%s: actual %r, expected %r' % (key,
-                                                  actual_value,
-                                                  expected_value)
+            message = '%s: actual %r, expected %r' % (key,
+                                                      actual_value,
+                                                      expected_value)
 
-        if precision is not None:
-            self.assertAlmostEqual(float(actual_value),
-                                   float(expected_value),
-                                   places=precision,
-                                   msg=message)
-        else:
-            self.assertEqual(actual_value, expected_value, message)
+            if precision is not None:
+                self.assertAlmostEqual(float(actual_value),
+                                       float(expected_value),
+                                       places=precision,
+                                       msg=message)
+            else:
+                self.assertEqual(actual_value, expected_value, message)
 
     def assertUnpublishedMetricMany(self, mock, dict, expected_value=0):
         return self.assertPublishedMetricMany(mock, dict, expected_value)


### PR DESCRIPTION
Change as discussed on python-diamond/Diamond#287