### PR TITLE
Updating Debian changelog version for debuild.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+diamond (4.0.0) unstable; urgency=low
+  * new upstream
+ -- Rob Smith <kormoc@gmail.com>  Wed, 31 Dec 2014 15:19:00 -0800
+
 diamond (3.1.0) unstable; urgency=low
   * new upstream
  -- Rob Smith <kormoc@gmail.com>  Tue, 05 Nov 2012 15:19:00 -0800


### PR DESCRIPTION
This file determines what version is built when you do a "debuild".  It needs to be updated as part of the release process, grabbing the 4.0 release file and doing "debuild" currently results in a 3.1.0 being built.
