### PR TITLE
#219 - changing snmp base collector to actually implement collect

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -19,3 +19,4 @@ simplejson
 setproctitle
 psycopg2
 PySensors
+pysnmp

--- a/src/collectors/snmp/snmp.py
+++ b/src/collectors/snmp/snmp.py
@@ -35,6 +35,10 @@ import diamond.collector
 
 class SNMPCollector(diamond.collector.Collector):
 
+    def __init__(self, *args, **kwargs):
+        super(SNMPCollector, self).__init__(*args, **kwargs)
+        self.snmpCmdGen = cmdgen.CommandGenerator()
+
     def get_default_config_help(self):
         config_help = super(SNMPCollector, self).get_default_config_help()
         config_help.update({
@@ -59,6 +63,13 @@ class SNMPCollector(diamond.collector.Collector):
 
     def _convert_from_oid(self, oid):
         return ".".join([str(x) for x in oid])
+
+    def collect(self):
+        for device in self.config['devices']:
+            host = self.config['devices'][device]['host']
+            port = self.config['devices'][device]['port']
+            community = self.config['devices'][device]['community']
+            self.collect_snmp(device, host, port, community)
 
     def get(self, oid, host, port, community):
         """


### PR DESCRIPTION
Unless I missed something terribly obvious the SNMP base collector (used by all the other SNMP collectors like SNMPRawCollector, SNMPInterfaceCollector, etc) never implemented the collect() method, resulting in a NotImplementedException every time you tried to use one of these.

It's not really obvious to me how this was ever working or how it got to this state... Perhaps there was an API change at some point in the past or something.

Nevertheless, I've quickly hacked a change that makes it work (though I haven't really tested it with all the SNMP collectors, nor have I written any tests for this) and I'd like to get some feedback :)
