### PR TITLE
Ignore further SIGHUPs when handling it

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -203,7 +203,13 @@ class Server(object):
                 time.sleep(1)
 
             except SIGHUPException:
+                # ignore further SIGHUPs for now
+                original_sighup_handler = signal.getsignal(signal.SIGHUP)
+                signal.signal(signal.SIGHUP, signal.SIG_IGN)
+
                 self.log.info('Reloading state due to HUP')
                 self.config = load_config(self.configfile)
                 collectors = load_collectors(
                     self.config['server']['collectors_path'])
+                # restore SIGHUP handler
+                signal.signal(signal.SIGHUP, original_sighup_handler)


### PR DESCRIPTION
Otherwise a `SIGHUPException` would be raised and crash diamond