### PR TITLE
Do not set signal action for SIGHUP on Windows

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -124,7 +124,8 @@ class Server(object):
         # Signals
         #######################################################################
 
-        signal.signal(signal.SIGHUP, signal_to_exception)
+        if hasattr(signal, 'SIGHUP'):
+            signal.signal(signal.SIGHUP, signal_to_exception)
 
         #######################################################################
 


### PR DESCRIPTION
SIGHUP is not available on Windows, so lets skip it over.

If you take a look at `signal_to_exception` then it is even worse as none of these signals available on Windows as well.

```
def signal_to_exception(signum, frame):
    """
    Called by the timeout alarm during the collector run time
    """
    if signum == signal.SIGALRM:
        raise SIGALRMException()
    if signum == signal.SIGHUP:
        raise SIGHUPException()
    if signum == signal.SIGUSR1:
        raise SIGUSR1Exception()
    if signum == signal.SIGUSR2:
        raise SIGUSR2Exception()
    raise SignalException(signum)
```