### PR TITLE
Calamari

### DIFF
--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -17,16 +17,27 @@ import glob
 import os
 import subprocess
 import re
-from collections import defaultdict
-from distutils.version import StrictVersion
 import diamond.collector
+import diamond.convertor
 from diamond.collector import str_to_bool
 
 
-def flatten_dictionary(input_dict, sep='.', prefix=None):
-    """Produces iterator of pairs where the first value is
-    the joined key names and the second value is the value
-    associated with the lowest level key. For example::
+# Metric name/path separator
+_PATH_SEP = "."
+
+_NSEC_PER_SEC = 1000000000
+
+# Performance metric data types
+_PERFCOUNTER_NONE = 0
+_PERFCOUNTER_TIME = 0x1
+_PERFCOUNTER_U64 = 0x2
+_PERFCOUNTER_LONGRUNAVG = 0x4
+_PERFCOUNTER_COUNTER = 0x8
+
+
+def flatten_dictionary(input_dict, path=list()):
+    """Produces iterator of pairs where the first value is the key path and
+    the second value is the value associated with the key. For example::
 
       {'a': {'b': 10},
        'c': 20,
@@ -34,15 +45,49 @@ def flatten_dictionary(input_dict, sep='.', prefix=None):
 
     produces::
 
-      [('a.b', 10), ('c', 20)]
+      [([a,b], 10), ([c], 20)]
     """
     for name, value in sorted(input_dict.items()):
-        fullname = sep.join(filter(None, [prefix, name]))
+        path.append(name)
         if isinstance(value, dict):
-            for result in flatten_dictionary(value, sep, fullname):
+            for result in flatten_dictionary(value, path):
                 yield result
         else:
-            yield (fullname, value)
+            yield (path[:], value)
+        del path[-1]
+
+
+def lookup_dict_path(d, path, extra=list()):
+    """Lookup value in dictionary based on path + extra.
+
+    For instance, [a,b,c] -> d[a][b][c]
+    """
+    element = None
+    for component in path + extra:
+        d = d[component]
+        element = d
+    return element
+
+
+class CalledProcessError(Exception):
+    pass
+
+
+def _popen_check_output(*popenargs):
+    """
+    Collect Popen output and check for errors.
+
+    This is inspired by subprocess.check_output, added in Python 2.7. This
+    method provides similar functionality but will work with Python 2.6.
+    """
+    process = subprocess.Popen(*popenargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        msg = "Command '%s' exited with non-zero status %d" % \
+              (popenargs[0], retcode)
+        raise CalledProcessError(msg)
+    return output, err
 
 
 class AdminSocketError(Exception):
@@ -72,6 +117,7 @@ class CephCollector(diamond.collector.Collector):
         super(CephCollector, self).__init__(config, handlers)
         self.config['short_names'] = str_to_bool(self.config['short_names'])
         self.config['service_stats_global'] = str_to_bool(self.config['service_stats_global'])
+        self.config['perf_counters_enabled'] = str_to_bool(self.config['perf_counters_enabled'])
 
     def get_default_config_help(self):
         config_help = super(CephCollector, self).get_default_config_help()
@@ -103,7 +149,8 @@ class CephCollector(diamond.collector.Collector):
             'ceph_binary': '/usr/bin/ceph',
             'short_names': True,
             'cluster_prefix': 'ceph.cluster',
-            'service_stats_global': False
+            'service_stats_global': False,
+            'perf_counters_enabled': True
         })
         return config
 
@@ -134,37 +181,167 @@ class CephCollector(diamond.collector.Collector):
         return re.match("^(.*)-(.*)\.(.*).{0}$".format(self.config['socket_ext']),
                         os.path.basename(path)).groups()
 
-    def _publish_stats(self, counter_prefix, stats, global_name=False, counter=False):
-        """Given a stats dictionary from _get_stats_from_socket,
-        publish the individual values.
+    def _publish_longrunavg(self, counter_prefix, stats, path, stat_type):
+        """Publish a long-running average metric.
+
+        A long-running metric has two components: 'avgcount' and 'sum'. We
+        publish both the raw components, and a derived metric named
+        <metric>.last_interval_avg that is the average since the last run of
+        the collector.
+
+        For a given long-running average metric with name <metric>, we publish
+        the following derived metrics:
+
+            <metric>.sum
+            <metric>.count
+            <metric>.last_interval_avg
+
+        Args:
+            counter_prefix: string prefixed to metric names
+            stats: dictionary containing performance counters
+            path: full path of the metric name (e.g. [osd, op_rw_rlat])
+            stat_type: the metric type taken from the schema
         """
+        # name of <metric>
+        base_name = _PATH_SEP.join(filter(None, [counter_prefix] + path))
+        total_sum_name = "%s%s%s" % (base_name, _PATH_SEP, "sum")
+        total_count_name = "%s%s%s" % (base_name, _PATH_SEP, "count")
+        delta_sum_name = "%s%s%s" % (base_name, _PATH_SEP, "delta_sum")
+        delta_count_name = "%s%s%s" % (base_name, _PATH_SEP, "delta_count")
+        delta_avg_name = "%s%s%s" % (base_name, _PATH_SEP, "last_interval_avg")
+
+        # lookup raw metric component values
+        total_sum = lookup_dict_path(stats, path, ['sum'])
+        total_count = lookup_dict_path(stats, path, ['avgcount'])
+
+        # perform metric-specific type conversions
+        if stat_type & _PERFCOUNTER_TIME:
+            total_sum = self._ceph_time_to_seconds(total_sum)
+
+        # Calculate deltas since last time we queried admin socket. The
+        # derivitive function records from the last invocation the
+        # total_sum/total_count, and simply returns the difference.
+        delta_sum = self.derivative(delta_sum_name, total_sum, time_delta=False)
+        delta_count = self.derivative(delta_count_name, total_count, time_delta=False)
+
+        # average in the last collection interval
+        if delta_count == 0:
+            delta_avg = 0
+        else:
+            delta_avg = float(delta_sum) / float(delta_count)
+
+        # publish raw data
+        self.publish_gauge(total_sum_name, total_sum)
+        self.publish_gauge(total_count_name, total_count)
+
+        # publish averages
+        self.publish_gauge(delta_avg_name, delta_avg, 6)
+
+    def _ceph_time_to_seconds(self, val):
+        """Convert Ceph time format into seconds.  Older Ceph
+           versions output times as a string, while newer
+           versions output a float (which we pass through)
+
+        :param val: string in format "seconds.nanoseconds" or
+                    floating point number.
+
+        Returns:
+            Time in seconds as a floating point number.
+        """
+        if isinstance(val, basestring):
+            sec, nsec = map(lambda v: long(v), val.split("."))
+            return float(sec * _NSEC_PER_SEC + nsec) / float(_NSEC_PER_SEC)
+        else:
+            return val
+
+    def _get_byte_metrics(self, name, metric_value):
+        """Return list of metrics derived from byte units.
+
+        Args:
+            name: the name of the metric
+            metric_value: the value of the metric in bytes
+
+        Returns:
+            List of (name, value) pairs for each unit.
+        """
+        assert name.endswith("bytes")
+        result = []
+        for unit in self.config['byte_unit']:
+            new_value = diamond.convertor.binary.convert(
+                value=metric_value, oldUnit='byte', newUnit=unit)
+            new_name = name.replace("bytes", unit)
+            result.append((new_name, new_value))
+        return result
+
+    def _publish_stats(self, counter_prefix, stats, schema, global_name=False):
+        """Publish a set of Ceph performance counters, including schema.
+
+        :param counter_prefix: string prefixed to metric names
+        :param stats: dictionary containing performance counters
+        :param schema: performance counter schema
+        """
+        for path, stat_type in flatten_dictionary(schema):
+            # remove 'stat_type' component to get metric name
+            assert path[-1] == 'type'
+            del path[-1]
+
+            if stat_type & _PERFCOUNTER_LONGRUNAVG:
+                self._publish_longrunavg(counter_prefix, stats, path, stat_type)
+            else:
+                name = _PATH_SEP.join(filter(None, [counter_prefix] + path))
+                if global_name:
+                    name = GlobalName(name)
+
+                value = lookup_dict_path(stats, path)
+
+                if stat_type & _PERFCOUNTER_TIME:
+                    value = self._ceph_time_to_seconds(value)
+                    self.publish_gauge(name, value, 6)
+
+                elif stat_type & _PERFCOUNTER_U64:
+                    # create a list of values to log. we'll either log a list
+                    # of derived metrics, or the single metric we began with.
+                    if name.endswith("bytes"):
+                        values = self._get_byte_metrics(name, value)
+                    else:
+                        values = [(name, value)]
+
+                    for name, value in values:
+                        if stat_type & _PERFCOUNTER_COUNTER:
+                            self.publish_counter(name, value, 2)
+                        else:
+                            self.publish_gauge(name, value, 2)
+                else:
+                    self.log.error("Unexpected metric stat_type: %s/%d", name, stat_type)
+
+    def _cluster_id_prefix(self, cluster_name, fsid):
+        # We'll either use the cluster name (human friendly but may not be unique)
+        # or the UUID (robust but obscure)
+        if self.config['short_names']:
+            return cluster_name
+        else:
+            return fsid
+
+    def _publish_cluster_stats(self, cluster_name, fsid, prefix, stats, counter=False):
+        """
+        Given a stats dictionary, publish under the cluster path (respecting
+        short_names and cluster_prefix)
+        """
+
+
         for stat_name, stat_value in flatten_dictionary(
             stats,
-            prefix=counter_prefix,
+            path=[self._cluster_id_prefix(cluster_name, fsid), prefix]
         ):
-            name = GlobalName(stat_name) if global_name else stat_name
+            name = GlobalName(stat_name)
             if counter:
                 self.publish_counter(name, stat_value)
             else:
                 self.publish_gauge(name, stat_value)
 
-    def _publish_cluster_stats(self, cluster_name, fsid, prefix, stats, counter=False):
-        """
-        Given a stats dictionary, publish under the cluster path (respecting
-        short_names and cluster_prefix
-        """
-        # We'll either use the cluster name (human friendly but may not be unique)
-        # or the UUID (robust but obscure)
-        if self.config['short_names']:
-            cluster_id_prefix = cluster_name
-        else:
-            cluster_id_prefix = fsid
-
-        self._publish_stats("{0}.{1}".format(cluster_id_prefix, prefix), stats, global_name=True, counter=counter)
-
     def _admin_command(self, socket_path, command):
         try:
-            json_blob = subprocess.check_output(
+            json_blob, err = _popen_check_output(
                 [self.config['ceph_binary'], '--admin-daemon', socket_path] + command)
         except subprocess.CalledProcessError:
             self.log.exception('Error calling to %s' % socket_path)
@@ -178,7 +355,7 @@ class CephCollector(diamond.collector.Collector):
 
     def _mon_command(self, cluster, command):
         try:
-            json_blob = subprocess.check_output(
+            json_blob, err = _popen_check_output(
                 [self.config['ceph_binary'], '--cluster', cluster, '-f', 'json-pretty'] + command)
         except subprocess.CalledProcessError:
             raise MonError(cluster, command)
@@ -226,18 +403,34 @@ class CephCollector(diamond.collector.Collector):
         df = self._mon_command(cluster_name, ['df'])
         self._publish_cluster_stats(cluster_name, fsid, "df", df['stats'])
 
+    def _get_perf_counters(self, name):
+        """Return perf counters and schema from admin socket.
+
+        Args:
+            name: path to admin socket
+
+        Returns:
+            Tuple (counters, schema)
+        """
+        counters = self._admin_command(name, ['perf', 'dump'])
+        schema = self._admin_command(name, ['perf', 'schema'])
+        return counters, schema
+
     def _collect_service_stats(self, path):
+        if not self.config['perf_counters_enabled']:
+            return
+
         cluster_name, service_type, service_id = self._parse_socket_name(path)
         fsid = self._admin_command(path, ['config', 'get', 'fsid'])['fsid']
 
-        stats = self._admin_command(path, ['perf', 'dump'])
+        stats, schema = self._get_perf_counters(path)
         if self.config['service_stats_global']:
-            counter_prefix = "{0}.{1}".format(service_type, service_id)
-            self._publish_cluster_stats(cluster_name, fsid, counter_prefix, stats)
+            counter_prefix = "{0}.{1}.{2}".format(self._cluster_id_prefix(cluster_name, fsid), service_type, service_id)
+            self._publish_stats(cluster_name, fsid, counter_prefix, stats, global_name=True)
         else:
             # The prefix is <cluster name>.<service type>.<service id>
             counter_prefix = "{0}.{1}.{2}".format(cluster_name, service_type, service_id)
-            self._publish_stats(counter_prefix, stats)
+            self._publish_stats(counter_prefix, stats, schema)
 
     def collect(self):
         """

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 """
-The CephCollector collects utilization info from the Ceph storage system.
+The CephCollector collects utilization info from Ceph services.
 
 Documentation for ceph perf counters:
 http://ceph.com/docs/master/dev/perf_counters/
@@ -12,22 +12,17 @@ http://ceph.com/docs/master/dev/perf_counters/
 
 """
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json  # No need for simplejson fallback b/c ceph py modules are >=2.6
 import glob
 import os
 import subprocess
 import re
+from collections import defaultdict
 from distutils.version import StrictVersion
-
-
 import diamond.collector
 
 
-def flatten_dictionary(input, sep='.', prefix=None):
+def flatten_dictionary(input_dict, sep='.', prefix=None):
     """Produces iterator of pairs where the first value is
     the joined key names and the second value is the value
     associated with the lowest level key. For example::
@@ -40,7 +35,7 @@ def flatten_dictionary(input, sep='.', prefix=None):
 
       [('a.b', 10), ('c', 20)]
     """
-    for name, value in sorted(input.items()):
+    for name, value in sorted(input_dict.items()):
         fullname = sep.join(filter(None, [prefix, name]))
         if isinstance(value, dict):
             for result in flatten_dictionary(value, sep, fullname):
@@ -67,6 +62,10 @@ class MonError(Exception):
         return "Mon command error calling %s on cluster %s" % (self.command, self.cluster_name)
 
 
+class GlobalName(str):
+    pass
+
+
 class CephCollector(diamond.collector.Collector):
     def get_default_config_help(self):
         config_help = super(CephCollector, self).get_default_config_help()
@@ -77,6 +76,13 @@ class CephCollector(diamond.collector.Collector):
                           ' Defaults to "asok"',
             'ceph_binary': 'Path to "ceph" executable. '
                            'Defaults to /usr/bin/ceph.',
+            'short_names': "If true, use cluster names instead of UUIDs"
+                           "in metric paths.  Defaults to true.",
+            'cluster_prefix': "Prefix for per-cluster metrics.  Defaults"
+                           "to 'ceph.cluster'.",
+            'service_stats_global': "If true, stats from osds and mons are"
+                                    "stored under the cluster prefix (not by host).  If false, these"
+                                    "stats are stored in per-host paths."
         })
         return config_help
 
@@ -89,8 +95,22 @@ class CephCollector(diamond.collector.Collector):
             'socket_path': '/var/run/ceph',
             'socket_ext': 'asok',
             'ceph_binary': '/usr/bin/ceph',
+            'short_names': True,
+            'cluster_prefix': 'ceph.cluster',
+            'service_stats_global': False
         })
         return config
+
+    def get_metric_path(self, name, instance=None):
+        """
+        This collector returns some cluster-wide statistics rather than
+        server-specific statistics, so we override this to
+        avoid diamond prefixing the hostname to our metrics.
+        """
+        if isinstance(name, GlobalName):
+            return ".".join([self.config['cluster_prefix'], name])
+        else:
+            return super(CephCollector, self).get_metric_path(name, instance)
 
     def _get_socket_paths(self):
         """Return a sequence of paths to sockets for communicating
@@ -108,7 +128,7 @@ class CephCollector(diamond.collector.Collector):
         return re.match("^(.*)-(.*)\.(.*).{0}$".format(self.config['socket_ext']),
                         os.path.basename(path)).groups()
 
-    def _publish_stats(self, counter_prefix, stats):
+    def _publish_stats(self, counter_prefix, stats, global_name=False):
         """Given a stats dictionary from _get_stats_from_socket,
         publish the individual values.
         """
@@ -116,20 +136,21 @@ class CephCollector(diamond.collector.Collector):
             stats,
             prefix=counter_prefix,
         ):
-            self.publish_gauge(stat_name, stat_value)
+            self.publish_gauge(GlobalName(stat_name) if global_name else stat_name, stat_value)
 
-    def _mon_command(self, cluster, command):
-        try:
-            json_blob = subprocess.check_output(
-                [self.config['ceph_binary'], '--cluster', cluster, '-f', 'json-pretty'] + command)
-        except subprocess.CalledProcessError:
-            raise MonError(cluster, command)
+    def _publish_cluster_stats(self, cluster_name, fsid, prefix, stats):
+        """
+        Given a stats dictionary, publish under the cluster path (respecting
+        short_names and cluster_prefix
+        """
+        # We'll either use the cluster name (human friendly but may not be unique)
+        # or the UUID (robust but obscure)
+        if self.config['short_names']:
+            cluster_id_prefix = cluster_name
+        else:
+            cluster_id_prefix = fsid
 
-        try:
-            return json.loads(json_blob)
-        except (ValueError, IndexError):
-            self.log.exception('Error parsing output from %s: %s' % (cluster, command))
-            raise MonError(cluster, command)
+        self._publish_stats("{0}.{1}".format(cluster_id_prefix, prefix), stats, global_name=True)
 
     def _admin_command(self, socket_path, command):
         try:
@@ -145,7 +166,24 @@ class CephCollector(diamond.collector.Collector):
             self.log.exception('Error parsing output from %s' % socket_path)
             raise AdminSocketError(socket_path, command)
 
+    def _mon_command(self, cluster, command):
+        try:
+            json_blob = subprocess.check_output(
+                [self.config['ceph_binary'], '--cluster', cluster, '-f', 'json-pretty'] + command)
+        except subprocess.CalledProcessError:
+            raise MonError(cluster, command)
+
+        try:
+            return json.loads(json_blob)
+        except (ValueError, IndexError):
+            self.log.exception('Error parsing output from %s: %s' % (cluster, command))
+            raise MonError(cluster, command)
+
     def _collect_cluster_stats(self, path):
+        """
+        If this service is a mon and it is the leader of a quorum, then
+        publish statistics about the cluster.
+        """
         cluster_name, service_type, service_id = self._parse_socket_name(path)
         if service_type != 'mon':
             return
@@ -154,46 +192,98 @@ class CephCollector(diamond.collector.Collector):
         version_str = self._admin_command(path, ['version'])['version']
         try:
             version = StrictVersion(version_str)
-            # We expect to backport pool stats to the dumpling release series
-            # in the next release, and the current release at time of writing
-            # is 0.67.4.
-            if version < StrictVersion("0.67.5"):
-                return
         except ValueError:
-            # If it doesn't parse, assume it's a git hash, therefore
-            # it should be recent and have the features we want.
-            pass
+            # In case it's a git hash or something like that
+            version = None
 
         # We have a mon, see if it is the leader
         mon_status = self._admin_command(path, ['mon_status'])
         if mon_status['state'] != 'leader':
             return
-
-        self.log.debug("mon leader found, gathering cluster stats for cluster '%s'" % cluster_name)
+        fsid = mon_status['monmap']['fsid']
 
         # We are the leader, gather cluster-wide statistics
-        for pool_data in self._mon_command(cluster_name, ['osd', 'pool', 'stats']):
-            pool_id = pool_data['pool_id']
-            del pool_data['pool_name']
-            del pool_data['pool_id']
-            self._publish_stats(
-                "{0}ceph.{1}.pool.{2}".format(diamond.collector.ABSOLUTE_PATH_MARKER, cluster_name, pool_id),
-                pool_data
-            )
+        self.log.debug("mon leader found, gathering cluster stats for cluster '%s'" % cluster_name)
 
+        # Recent Ceph versions have some per-pool statistics for us
+        if version is None or version >= StrictVersion("0.67.5"):
+            # Not everything in the pool stats makes sense to sum (e.g. ratios), so
+            # we have an explicit list of which items to put into the 'all' pool.
+            aggregates = {
+                'client_io_rate': {
+                    'op_per_sec': 0,
+                    'write_bytes_sec': 0,
+                    'read_bytes_sec': 0
+                },
+                'recovery': {
+                    'degraded_objects': 0,
+                    'degraded_total': 0,
+                },
+                'recovery_rate': {
+                    'recovering_objects_per_sec': 0,
+                    'recovering_keys_per_sec': 0,
+                    'recovering_bytes_per_sec': 0,
+                }
+            }
+            for pool_data in self._mon_command(cluster_name, ['osd', 'pool', 'stats']):
+                pool_id = pool_data['pool_id']
+                del pool_data['pool_name']
+                del pool_data['pool_id']
+
+                for k, v in aggregates.items():
+                    if k in pool_data:
+                        pool_data_k = pool_data[k]
+                        for k2, v2 in v.items():
+                            if k2 in pool_data_k:
+                                v[k2] += pool_data_k[k2]
+
+                self._publish_cluster_stats(cluster_name, fsid,
+                                            "pool.{0}".format(pool_id),
+                                            pool_data)
+            self._publish_cluster_stats(cluster_name, fsid,
+                                        "pool.all",
+                                        aggregates)
+
+        # Older Ceph versions only give us some global throughput stats
+        if version <= StrictVersion("0.67.4"):
+            summary = self._mon_command(cluster_name, ['pg', 'dump', 'summary'])
+            pg_stats_delta = summary['pg_stats_delta']['stat_sum']
+
+            # We will synthesize the 'client_io_rate.op_per_sec' statistic that
+            # would otherwise come from 'osd pool stats'
+            tick_period = 5.0  # We assume this has been left as the default
+            op_per_sec = (pg_stats_delta['num_write'] + pg_stats_delta['num_read']) / tick_period
+            self._publish_cluster_stats(cluster_name, fsid,
+                                        "pool.all",
+                                        {'client_io_rate': {"op_per_sec": op_per_sec}})
+
+        # Gather "ceph df" and file the stats by pool
         df = self._mon_command(cluster_name, ['df'])
-        self._publish_stats("{0}ceph.{1}.df".format(diamond.collector.ABSOLUTE_PATH_MARKER, cluster_name), df['stats'])
+        self._publish_cluster_stats(cluster_name, fsid, "df", df['stats'])
+        all_pools_df = defaultdict(int)
         for pool_data in df['pools']:
-            self._publish_stats(
-                "{0}ceph.{1}.pool.{2}".format(diamond.collector.ABSOLUTE_PATH_MARKER, cluster_name, pool_data['id']),
-                pool_data['stats']
-            )
+            self._publish_cluster_stats(cluster_name, fsid,
+                                        "pool.{0}".format(pool_data['id']),
+                                        pool_data['stats'])
+
+            for k, v in pool_data['stats'].items():
+                all_pools_df[k] += v
+        self._publish_cluster_stats(cluster_name, fsid,
+                                    "pool.all",
+                                    all_pools_df)
 
     def _collect_service_stats(self, path):
-        # The prefix is <cluster name>.<service type>.<service id>
-        counter_prefix = "{0}.{1}.{2}".format(*self._parse_socket_name(path))
+        cluster_name, service_type, service_id = self._parse_socket_name(path)
+        fsid = self._admin_command(path, ['config', 'get', 'fsid'])['fsid']
+
         stats = self._admin_command(path, ['perf', 'dump'])
-        self._publish_stats(counter_prefix, stats)
+        if self.config['service_stats_global']:
+            counter_prefix = "{0}.{1}".format(service_type, service_id)
+            self._publish_cluster_stats(cluster_name, fsid, counter_prefix, stats)
+        else:
+            # The prefix is <cluster name>.<service type>.<service id>
+            counter_prefix = "{0}.{1}.{2}".format(*self._parse_socket_name(path))
+            self._publish_stats(counter_prefix, stats)
 
     def collect(self):
         """
@@ -201,9 +291,6 @@ class CephCollector(diamond.collector.Collector):
         """
         for path in self._get_socket_paths():
             self.log.debug('gathering service stats for %s', path)
-            # Publish statistics about this service
-            self._collect_service_stats(path)
 
-            # If this service is a mon and it is the leader of a quorum, then
-            # publish statistics about the cluster.
+            self._collect_service_stats(path)
             self._collect_cluster_stats(path)

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -222,21 +222,9 @@ class CephCollector(diamond.collector.Collector):
         all_pools_stats = self._mon_command(cluster_name, ['pg', 'dump', 'summary'])['pg_stats_sum']['stat_sum']
         publish_pool_stats('all', all_pools_stats)
 
-        # Gather "ceph df" and file the stats by pool
+        # Gather "ceph df"
         df = self._mon_command(cluster_name, ['df'])
         self._publish_cluster_stats(cluster_name, fsid, "df", df['stats'])
-        all_pools_df = defaultdict(int)
-        for pool_data in df['pools']:
-            self._publish_cluster_stats(cluster_name, fsid,
-                                        "pool.{0}".format(pool_data['id']),
-                                        pool_data['stats'])
-
-            for k, v in pool_data['stats'].items():
-                all_pools_df[k] += v
-
-        self._publish_cluster_stats(cluster_name, fsid,
-                                    "pool.all",
-                                    all_pools_df)
 
     def _collect_service_stats(self, path):
         cluster_name, service_type, service_id = self._parse_socket_name(path)

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -35,7 +35,7 @@ _PERFCOUNTER_LONGRUNAVG = 0x4
 _PERFCOUNTER_COUNTER = 0x8
 
 
-def flatten_dictionary(input_dict, path=list()):
+def flatten_dictionary(input_dict, path=None):
     """Produces iterator of pairs where the first value is the key path and
     the second value is the value associated with the key. For example::
 
@@ -47,6 +47,9 @@ def flatten_dictionary(input_dict, path=list()):
 
       [([a,b], 10), ([c], 20)]
     """
+    if path is None:
+        path = []
+
     for name, value in sorted(input_dict.items()):
         path.append(name)
         if isinstance(value, dict):

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -342,7 +342,6 @@ class CephCollector(diamond.collector.Collector):
         short_names and cluster_prefix)
         """
 
-
         for stat_name, stat_value in flatten_dictionary(
             stats,
             path=[self._cluster_id_prefix(cluster_name, fsid), prefix]

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -302,7 +302,8 @@ class CephCollector(diamond.collector.Collector):
         """
         for path, stat_type in flatten_dictionary(schema):
             # remove 'stat_type' component to get metric name
-            assert path[-1] == 'type'
+            if path[-1] != 'type':
+                continue
             del path[-1]
 
             if stat_type & _PERFCOUNTER_LONGRUNAVG:

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -444,7 +444,7 @@ class CephCollector(diamond.collector.Collector):
 
         if self.config['service_stats_global']:
             counter_prefix = "{0}.{1}.{2}".format(self._cluster_id_prefix(cluster_name, fsid), service_type, service_id)
-            self._publish_stats(cluster_name, fsid, counter_prefix, stats, global_name=True)
+            self._publish_stats(counter_prefix, stats, schema, global_name=True)
         else:
             # The prefix is <cluster name>.<service type>.<service id>
             counter_prefix = "{0}.{1}.{2}".format(cluster_name, service_type, service_id)

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -333,6 +333,7 @@ class CephCollector(diamond.collector.Collector):
             stats,
             path=[self._cluster_id_prefix(cluster_name, fsid), prefix]
         ):
+            stat_name = _PATH_SEP.join(stat_name)
             name = GlobalName(stat_name)
             if counter:
                 self.publish_counter(name, stat_value)

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -20,6 +20,7 @@ import re
 from collections import defaultdict
 from distutils.version import StrictVersion
 import diamond.collector
+from diamond.collector import str_to_bool
 
 
 def flatten_dictionary(input_dict, sep='.', prefix=None):
@@ -67,6 +68,11 @@ class GlobalName(str):
 
 
 class CephCollector(diamond.collector.Collector):
+    def __init__(self, config, handlers):
+        super(CephCollector, self).__init__(config, handlers)
+        self.config['short_names'] = str_to_bool(self.config['short_names'])
+        self.config['service_stats_global'] = str_to_bool(self.config['service_stats_global'])
+
     def get_default_config_help(self):
         config_help = super(CephCollector, self).get_default_config_help()
         config_help.update({
@@ -242,7 +248,7 @@ class CephCollector(diamond.collector.Collector):
             self._publish_cluster_stats(cluster_name, fsid, counter_prefix, stats)
         else:
             # The prefix is <cluster name>.<service type>.<service id>
-            counter_prefix = "{0}.{1}.{2}".format(*self._parse_socket_name(path))
+            counter_prefix = "{0}.{1}.{2}".format(cluster_name, service_type, service_id)
             self._publish_stats(counter_prefix, stats)
 
     def collect(self):

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -119,8 +119,8 @@ class LocalName(str):
 
 
 class CephCollector(diamond.collector.Collector):
-    def __init__(self, config, handlers):
-        super(CephCollector, self).__init__(config, handlers)
+    def __init__(self, config=None, handlers=[], name=None, configfile=None):
+        super(CephCollector, self).__init__(config, handlers, name, configfile)
         self.config['short_names'] = str_to_bool(self.config['short_names'])
         self.config['service_stats_global'] = str_to_bool(self.config['service_stats_global'])
         self.config['perf_counters_enabled'] = str_to_bool(self.config['perf_counters_enabled'])

--- a/src/collectors/ceph/test/testceph.py
+++ b/src/collectors/ceph/test/testceph.py
@@ -147,10 +147,7 @@ class TestCephCollectorGettingStats(CollectorTestCase):
 
     @patch('ceph._popen_check_output')
     def test_ceph_command_fails(self, check_output):
-        # this test check very little since the exceptionhandling ws moved into collect
-        # We've checked elsewhere that check_output is getting called with specific params
-        # TODO delete or sub in collect for _get_perf_counters
-        check_output.side_effect = subprocess.CalledProcessError(
+        check_output.side_effect = ceph.CalledProcessError(
             255, ['/usr/bin/ceph'], 'error!',
         )
         with self.assertRaises(ceph.AdminSocketError):

--- a/src/collectors/ceph/test/testceph.py
+++ b/src/collectors/ceph/test/testceph.py
@@ -40,35 +40,21 @@ class TestCounterIterator(unittest.TestCase):
     @run_only_if_assertSequenceEqual_is_available
     def test_simple(self):
         data = {'a': 1, 'b': 2}
-        expected = [('a', 1), ('b', 2)]
+        expected = [(['a'], 1), (['b'], 2)]
         actual = list(ceph.flatten_dictionary(data))
-        self.assertSequenceEqual(actual, expected)
-
-    @run_only_if_assertSequenceEqual_is_available
-    def test_prefix(self):
-        data = {'a': 1, 'b': 2}
-        expected = [('Z.a', 1), ('Z.b', 2)]
-        actual = list(ceph.flatten_dictionary(data, prefix='Z'))
-        self.assertSequenceEqual(actual, expected)
-
-    @run_only_if_assertSequenceEqual_is_available
-    def test_sep(self):
-        data = {'a': 1, 'b': 2}
-        expected = [('Z:a', 1), ('Z:b', 2)]
-        actual = list(ceph.flatten_dictionary(data, prefix='Z', sep=':'))
         self.assertSequenceEqual(actual, expected)
 
     @run_only_if_assertSequenceEqual_is_available
     def test_nested(self):
         data = {'a': 1, 'b': 2, 'c': {'d': 3}}
-        expected = [('a', 1), ('b', 2), ('c.d', 3)]
+        expected = [(['a'], 1), (['b'], 2), (['c','d'], 3)]
         actual = list(ceph.flatten_dictionary(data))
         self.assertSequenceEqual(actual, expected)
 
     @run_only_if_assertSequenceEqual_is_available
     def test_doubly_nested(self):
         data = {'a': 1, 'b': 2, 'c': {'d': 3}, 'e': {'f': {'g': 1}}}
-        expected = [('a', 1), ('b', 2), ('c.d', 3), ('e.f.g', 1)]
+        expected = [(['a'], 1), (['b'], 2), (['c', 'd'], 3), (['e', 'f', 'g'], 1)]
         actual = list(ceph.flatten_dictionary(data))
         self.assertSequenceEqual(actual, expected)
 
@@ -81,11 +67,11 @@ class TestCounterIterator(unittest.TestCase):
                          "sum": 0},
                 }
         expected = [
-            ('get', 60910),
-            ('max', 524288000),
-            ('val', 0),
-            ('wait.avgcount', 0),
-            ('wait.sum', 0),
+            (['get'], 60910),
+            (['max'], 524288000),
+            (['val'], 0),
+            (['wait', 'avgcount'], 0),
+            (['wait', 'sum'], 0),
         ]
         actual = list(ceph.flatten_dictionary(data))
         self.assertSequenceEqual(actual, expected)
@@ -100,13 +86,13 @@ class TestCephCollectorSocketNameHandling(CollectorTestCase):
         self.collector = ceph.CephCollector(config, None)
 
     def test_counter_default_prefix(self):
-        expected = 'ceph.osd.325'
+        expected = 'ceph.osd-325'
         sock = '/var/run/ceph/ceph-osd.325.asok'
         actual = self.collector._get_counter_prefix_from_socket_name(sock)
         self.assertEquals(actual, expected)
 
     def test_counter_alternate_prefix(self):
-        expected = 'ceph.keep-osd.325'
+        expected = 'ceph.keep-osd-325'
         sock = '/var/run/ceph/keep-osd.325.asok'
         actual = self.collector._get_counter_prefix_from_socket_name(sock)
         self.assertEquals(actual, expected)
@@ -124,93 +110,93 @@ class TestCephCollectorSocketNameHandling(CollectorTestCase):
         glob_mock.assert_called_with('/path/prefix-*.ext')
 
 
-class TestCephCollectorGettingStats(CollectorTestCase):
-
-    def setUp(self):
-        config = get_collector_config('CephCollector', {
-            'interval': 10,
-        })
-        self.collector = ceph.CephCollector(config, None)
-
-    def test_import(self):
-        self.assertTrue(ceph.CephCollector)
-
-    @run_only_if_subprocess_check_output_is_available
-    @patch('subprocess.check_output')
-    def test_load_works(self, check_output):
-        expected = {'a': 1,
-                    'b': 2,
-                    }
-        check_output.return_value = json.dumps(expected)
-        actual = self.collector._get_stats_from_socket('a_socket_name')
-        check_output.assert_called_with(['/usr/bin/ceph',
-                                         '--admin-daemon',
-                                         'a_socket_name',
-                                         'perf',
-                                         'dump',
-                                         ])
-        self.assertEqual(actual, expected)
-
-    @run_only_if_subprocess_check_output_is_available
-    @patch('subprocess.check_output')
-    def test_ceph_command_fails(self, check_output):
-        check_output.side_effect = subprocess.CalledProcessError(
-            255, ['/usr/bin/ceph'], 'error!',
-        )
-        actual = self.collector._get_stats_from_socket('a_socket_name')
-        check_output.assert_called_with(['/usr/bin/ceph',
-                                         '--admin-daemon',
-                                         'a_socket_name',
-                                         'perf',
-                                         'dump',
-                                         ])
-        self.assertEqual(actual, {})
-
-    @run_only_if_subprocess_check_output_is_available
-    @patch('json.loads')
-    @patch('subprocess.check_output')
-    def test_json_decode_fails(self, check_output, loads):
-        input = {'a': 1,
-                 'b': 2,
-                 }
-        check_output.return_value = json.dumps(input)
-        loads.side_effect = ValueError('bad data')
-        actual = self.collector._get_stats_from_socket('a_socket_name')
-        check_output.assert_called_with(['/usr/bin/ceph',
-                                         '--admin-daemon',
-                                         'a_socket_name',
-                                         'perf',
-                                         'dump',
-                                         ])
-        loads.assert_called_with(json.dumps(input))
-        self.assertEqual(actual, {})
-
-
-class TestCephCollectorPublish(CollectorTestCase):
-
-    def setUp(self):
-        config = get_collector_config('CephCollector', {
-            'interval': 10,
-        })
-        self.collector = ceph.CephCollector(config, None)
-
-    @patch.object(Collector, 'publish')
-    def test_simple(self, publish_mock):
-        self.collector._publish_stats('prefix', {'a': 1})
-        publish_mock.assert_called_with('prefix.a', 1,
-                                        metric_type='GAUGE', instance=None,
-                                        precision=0)
-
-    @patch.object(Collector, 'publish')
-    def test_multiple(self, publish_mock):
-        self.collector._publish_stats('prefix', {'a': 1, 'b': 2})
-        publish_mock.assert_has_calls([call('prefix.a', 1,
-                                            metric_type='GAUGE', instance=None,
-                                            precision=0),
-                                       call('prefix.b', 2,
-                                            metric_type='GAUGE', instance=None,
-                                            precision=0),
-                                       ])
+#class TestCephCollectorGettingStats(CollectorTestCase):
+#
+#    def setUp(self):
+#        config = get_collector_config('CephCollector', {
+#            'interval': 10,
+#        })
+#        self.collector = ceph.CephCollector(config, None)
+#
+#    def test_import(self):
+#        self.assertTrue(ceph.CephCollector)
+#
+#    @run_only_if_subprocess_check_output_is_available
+#    @patch('subprocess.check_output')
+#    def test_load_works(self, check_output):
+#        expected = {'a': 1,
+#                    'b': 2,
+#                    }
+#        check_output.return_value = json.dumps(expected)
+#        actual = self.collector._get_stats_from_socket('a_socket_name')
+#        check_output.assert_called_with(['/usr/bin/ceph',
+#                                         '--admin-daemon',
+#                                         'a_socket_name',
+#                                         'perf',
+#                                         'dump',
+#                                         ])
+#        self.assertEqual(actual, expected)
+#
+#    @run_only_if_subprocess_check_output_is_available
+#    @patch('subprocess.check_output')
+#    def test_ceph_command_fails(self, check_output):
+#        check_output.side_effect = subprocess.CalledProcessError(
+#            255, ['/usr/bin/ceph'], 'error!',
+#        )
+#        actual = self.collector._get_stats_from_socket('a_socket_name')
+#        check_output.assert_called_with(['/usr/bin/ceph',
+#                                         '--admin-daemon',
+#                                         'a_socket_name',
+#                                         'perf',
+#                                         'dump',
+#                                         ])
+#        self.assertEqual(actual, {})
+#
+#    @run_only_if_subprocess_check_output_is_available
+#    @patch('json.loads')
+#    @patch('subprocess.check_output')
+#    def test_json_decode_fails(self, check_output, loads):
+#        input = {'a': 1,
+#                 'b': 2,
+#                 }
+#        check_output.return_value = json.dumps(input)
+#        loads.side_effect = ValueError('bad data')
+#        actual = self.collector._get_stats_from_socket('a_socket_name')
+#        check_output.assert_called_with(['/usr/bin/ceph',
+#                                         '--admin-daemon',
+#                                         'a_socket_name',
+#                                         'perf',
+#                                         'dump',
+#                                         ])
+#        loads.assert_called_with(json.dumps(input))
+#        self.assertEqual(actual, {})
+#
+#
+#class TestCephCollectorPublish(CollectorTestCase):
+#
+#    def setUp(self):
+#        config = get_collector_config('CephCollector', {
+#            'interval': 10,
+#        })
+#        self.collector = ceph.CephCollector(config, None)
+#
+#    @patch.object(Collector, 'publish')
+#    def test_simple(self, publish_mock):
+#        self.collector._publish_stats('prefix', {'a': 1})
+#        publish_mock.assert_called_with('prefix.a', 1,
+#                                        metric_type='GAUGE', instance=None,
+#                                        precision=0)
+#
+#    @patch.object(Collector, 'publish')
+#    def test_multiple(self, publish_mock):
+#        self.collector._publish_stats('prefix', {'a': 1, 'b': 2})
+#        publish_mock.assert_has_calls([call('prefix.a', 1,
+#                                            metric_type='GAUGE', instance=None,
+#                                            precision=0),
+#                                       call('prefix.b', 2,
+#                                            metric_type='GAUGE', instance=None,
+#                                            precision=0),
+#                                       ])
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/collectors/ceph/test/testceph.py
+++ b/src/collectors/ceph/test/testceph.py
@@ -48,8 +48,14 @@ class TestCounterIterator(unittest.TestCase):
 
     @run_only_if_assertSequenceEqual_is_available
     def test_doubly_nested(self):
-        data = {'a': 1, 'b': 2, 'c': {'d': 3}, 'e': {'f': {'g': 1}}}
-        expected = [(['a'], 1), (['b'], 2), (['c', 'd'], 3), (['e', 'f', 'g'], 1)]
+        data = {'a': 1,
+                'b': 2,
+                'c': {'d': 3},
+                'e': {'f': {'g': 1}}}
+        expected = [(['a'], 1),
+                    (['b'], 2),
+                    (['c', 'd'], 3),
+                    (['e', 'f', 'g'], 1)]
         actual = list(ceph.flatten_dictionary(data))
         self.assertSequenceEqual(actual, expected)
 
@@ -113,9 +119,9 @@ class TestCephCollectorGettingStats(CollectorTestCase):
     def test_load_works(self, check_output):
         expected = {'a': 1,
                     'b': 2,
-        }
+                    }
         check_output.return_value = (json.dumps(expected), "")
-        actual_stats, actual_schema = self.collector._get_perf_counters('a_socket_name')
+        stats, schema = self.collector._get_perf_counters('a_socket_name')
         self.assertListEqual(check_output.mock_calls,
                              [
                                  call(
@@ -137,7 +143,7 @@ class TestCephCollectorGettingStats(CollectorTestCase):
                                      ]
                                  ),
                              ])
-        self.assertEqual(actual_stats, expected)
+        self.assertEqual(stats, expected)
 
     @patch('ceph._popen_check_output')
     def test_ceph_command_fails(self, check_output):
@@ -148,7 +154,7 @@ class TestCephCollectorGettingStats(CollectorTestCase):
             255, ['/usr/bin/ceph'], 'error!',
         )
         with self.assertRaises(ceph.AdminSocketError):
-            actual_stats, actual_schema = self.collector._get_perf_counters('a_socket_name')
+            stats, schema = self.collector._get_perf_counters('a_socket_name')
 
         check_output.assert_called_with(['/usr/bin/ceph',
                                          '--admin-daemon',
@@ -166,7 +172,7 @@ class TestCephCollectorGettingStats(CollectorTestCase):
         check_output.return_value = (json.dumps(input), '')
         loads.side_effect = ValueError('bad data')
         with self.assertRaises(ceph.AdminSocketError):
-            actual_stats, actual_schema = self.collector._get_perf_counters('a_socket_name')
+            stats, schema = self.collector._get_perf_counters('a_socket_name')
 
         check_output.assert_called_with(['/usr/bin/ceph',
                                          '--admin-daemon',

--- a/src/collectors/ceph/test/testceph.py
+++ b/src/collectors/ceph/test/testceph.py
@@ -193,20 +193,48 @@ class TestCephCollectorPublish(CollectorTestCase):
 
     @patch.object(Collector, 'publish')
     def test_simple(self, publish_mock):
-        self.collector._publish_stats('prefix', {'a': 1})
-        publish_mock.assert_called_with('prefix.a', 1,
+        schema = {u'cluster': {u'a': {u'description': u'a version',
+                                      u'nick': u'',
+                                      u'type': 2}}}
+
+        self.collector._publish_stats('prefix',
+                                      {'cluster': {'a': 1}},
+                                      schema,
+                                      ceph.GlobalName)
+        publish_mock.assert_called_with('prefix.cluster.a', 1,
                                         metric_type='GAUGE', instance=None,
-                                        precision=0)
+                                        precision=2)
 
     @patch.object(Collector, 'publish')
     def test_multiple(self, publish_mock):
-        self.collector._publish_stats('prefix', {'a': 1, 'b': 2})
+        schema = {u'a': {u'description': u'a version',
+                         u'nick': u'',
+                         u'type': 2},
+                  u'b': {u'description': u'a version',
+                         u'nick': u'',
+                         u'type': 2}}
+
+        self.collector._publish_stats('prefix', {'a': 1, 'b': 2},
+                                      schema, ceph.GlobalName)
         publish_mock.assert_has_calls([call('prefix.a', 1,
                                             metric_type='GAUGE', instance=None,
-                                            precision=0),
+                                            precision=2),
                                        call('prefix.b', 2,
                                             metric_type='GAUGE', instance=None,
-                                            precision=0),
+                                            precision=2),
+                                       ])
+
+    @patch.object(Collector, 'publish')
+    def test_multiple_obeys_schema(self, publish_mock):
+        schema = {u'a': {u'description': u'a version',
+                         u'nick': u'',
+                         u'type': 2}}
+
+        self.collector._publish_stats('prefix', {'a': 1, 'b': 2},
+                                      schema, ceph.GlobalName)
+        publish_mock.assert_has_calls([call('prefix.a', 1,
+                                            metric_type='GAUGE', instance=None,
+                                            precision=2),
                                        ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a fork of the CephCollector that we've used in calamari since diamond3.4
I've rebased, cleaned up, fixed tests, and tested the package with real data
I look forward to discussing what needs to change in order to get this back upstream.

The main change here is to optionally roll up stats about a ceph cluster under one reporting structure instead of spreading it out under all the server nodes that comprise the cluster.
