### PR TITLE
Avoid crash when network data isn't there (ES 2.0)

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -356,7 +356,8 @@ class ElasticSearchCollector(diamond.collector.Collector):
 
         #
         # network
-        self._copy_two_level(metrics, 'network', data['network'])
+        if 'network' in data:
+            self._copy_two_level(metrics, 'network', data['network'])
 
         #
         # cluster (optional)


### PR DESCRIPTION
This is just a quick fix to avoid a KeyError exception, it allows the collector to work when polling ES 2.0 instead of crashing with:

```
Collector failed!#012Traceback (most recent call last):#012  File "/opt/diamond/local/lib/python2.7/site-packages/diamond/utils/scheduler.py", line 73, in collector_process
    collector._run()#012  File "/opt/diamond/local/lib/python2.7/site-packages/diamond/collector.py", line 472, in _run#012    self.collect()
  File "/opt/diamond/share/diamond/collectors/elasticsearch/elasticsearch.py", line 386, in collect
    self.collect_instance(alias, host, port)#012  File "/opt/diamond/share/diamond/collectors/elasticsearch/elasticsearch.py", line 359, in collect_instance#012    self._copy_two_level(metrics, 'network', data['network'])
KeyError: 'network'
```

I'll investigate further if the network stats are still available, but this should probably go in since the collector isn't usable at the moment with the latest elasticsearch release.