### PR TITLE
PR256 followup - with configurable queue size

### DIFF
--- a/conf/diamond.conf.example
+++ b/conf/diamond.conf.example
@@ -35,6 +35,11 @@ handlers_config_path = /etc/diamond/handlers/
 # Directory to load handler modules from
 handlers_path = /usr/share/diamond/handlers/
 
+# Maximum number of metrics waiting to be processed by handlers.
+# When metric queue is full, new metrics are dropped.
+metric_queue_size = 16384
+
+
 ################################################################################
 ### Options for handlers
 [handlers]

--- a/src/diamond/handler/queue.py
+++ b/src/diamond/handler/queue.py
@@ -35,7 +35,7 @@ class QueueHandler(Handler):
         try:
             self.queue.put(metric, block=False)
         except Queue.Full:
-            pass
+            self._throttle_error('Queue full, check handlers for delays')
 
     def flush(self):
         return self._flush()
@@ -49,4 +49,4 @@ class QueueHandler(Handler):
         try:
             self.queue.put(None, block=False)
         except Queue.Full:
-            pass
+            self._throttle_error('Queue full, check handlers for delays')

--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -49,6 +49,7 @@ class Server(object):
         self.handlers = []
         self.handler_queue = []
         self.modules = {}
+        self.metric_queue = None
 
         # We do this weird process title swap around to get the sync manager
         # title correct for ps
@@ -58,7 +59,6 @@ class Server(object):
         self.manager = multiprocessing.Manager()
         if setproctitle:
             setproctitle(oldproctitle)
-        self.metric_queue = self.manager.Queue(maxsize=16384)
 
     def run(self):
         """
@@ -71,6 +71,10 @@ class Server(object):
         self.config = load_config(self.configfile)
 
         collectors = load_collectors(self.config['server']['collectors_path'])
+        metric_queue_size = int(self.config['server'].get('metric_queue_size',
+                                                          16384))
+        self.metric_queue = self.manager.Queue(maxsize=metric_queue_size)
+        self.log.debug('metric_queue_size: %d', metric_queue_size)
 
         #######################################################################
         # Handlers


### PR DESCRIPTION
This is the same as PR #256, but I added logging (via `_throttle_error()`)  on `Queue.Full` and a configurable queue size via the `config['server']['metric_queue_size']` parameter, with a default of 16384.