### PR TITLE
suggest statsd in place of python-statsd

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -12,7 +12,7 @@ pymongo<3.0
 # Disable due to bad test cases
 # https://github.com/BrightcoveOS/Diamond/issues/650
 #pyrabbit
-python-statsd
+statsd
 pyutmp
 redis
 simplejson

--- a/src/diamond/handler/stats_d.py
+++ b/src/diamond/handler/stats_d.py
@@ -7,8 +7,8 @@ It's OK.
 
 #### Dependencies
 
- * [python-statsd](http://pypi.python.org/pypi/python-statsd/)
- * [statsd](https://github.com/etsy/statsd) v0.1.1 or newer.
+ * [statsd](https://pypi.python.org/pypi/statsd/) v2.0.0 or newer.
+ * A compatible implementation of [statsd](https://github.com/etsy/statsd)
 
 #### Configuration
 
@@ -49,6 +49,11 @@ class StatsdHandler(Handler):
             self.log.error('statsd import failed. Handler disabled')
             self.enabled = False
             return
+
+        if not hasattr(statsd, 'StatsClient'):
+            self.log.warn('python-statsd support is deprecated '
+                          'and will be removed in the future. '
+                          'Please use https://pypi.python.org/pypi/statsd/')
 
         # Initialize Options
         self.host = self.config['host']

--- a/src/diamond/handler/test/teststatsdhandler.py
+++ b/src/diamond/handler/test/teststatsdhandler.py
@@ -5,7 +5,6 @@
 from test import unittest
 from test import run_only
 from mock import patch
-from mock import ANY
 
 import configobj
 
@@ -25,11 +24,8 @@ def run_only_if_statsd_is_available(func):
 class TestStatsdHandler(unittest.TestCase):
 
     @run_only_if_statsd_is_available
-    @patch('statsd.Client')
+    @patch('statsd.StatsClient')
     def test_single_gauge(self, mock_client):
-        instance = mock_client.return_value
-        instance._send.return_value = 1
-
         config = configobj.ConfigObj()
         config['host'] = 'localhost'
         config['port'] = '9999'
@@ -39,20 +35,17 @@ class TestStatsdHandler(unittest.TestCase):
                         123, raw_value=123, timestamp=1234567,
                         host='will-be-ignored', metric_type='GAUGE')
 
-        expected_data = {
-            'servers.com.example.www.cpu.total.idle': '123|g'
-        }
+        expected_data = ('servers.com.example.www.cpu.total.idle', 123)
 
         handler = StatsdHandler(config)
         handler.process(metric)
-        mock_client._send.assert_called_with(ANY, expected_data)
+        handler.connection.gauge.assert_called_with(*expected_data)
+
+        handler.connection.send.assert_called_with()
 
     @run_only_if_statsd_is_available
-    @patch('statsd.Client')
+    @patch('statsd.StatsClient')
     def test_single_counter(self, mock_client):
-        instance = mock_client.return_value
-        instance._send.return_value = 1
-
         config = configobj.ConfigObj()
         config['host'] = 'localhost'
         config['port'] = '9999'
@@ -62,20 +55,17 @@ class TestStatsdHandler(unittest.TestCase):
                         5, raw_value=123, timestamp=1234567,
                         host='will-be-ignored', metric_type='COUNTER')
 
-        expected_data = {
-            'servers.com.example.www.cpu.total.idle': '123|c'
-        }
+        expected_data = ('servers.com.example.www.cpu.total.idle', 123)
 
         handler = StatsdHandler(config)
         handler.process(metric)
-        mock_client._send.assert_called_with(ANY, expected_data)
+        handler.connection.incr.assert_called_with(*expected_data)
+
+        handler.connection.send.assert_called_with()
 
     @run_only_if_statsd_is_available
-    @patch('statsd.Client')
+    @patch('statsd.StatsClient')
     def test_multiple_counter(self, mock_client):
-        instance = mock_client.return_value
-        instance._send.return_value = 1
-
         config = configobj.ConfigObj()
         config['host'] = 'localhost'
         config['port'] = '9999'
@@ -89,17 +79,14 @@ class TestStatsdHandler(unittest.TestCase):
                          7, raw_value=128, timestamp=1234567,
                          host='will-be-ignored', metric_type='COUNTER')
 
-        expected_data1 = {
-            'servers.com.example.www.cpu.total.idle': '123|c'
-        }
-
-        expected_data2 = {
-            'servers.com.example.www.cpu.total.idle': '5|c'
-        }
+        expected_data1 = ('servers.com.example.www.cpu.total.idle', 123)
+        expected_data2 = ('servers.com.example.www.cpu.total.idle', 5)
 
         handler = StatsdHandler(config)
         handler.process(metric1)
-        mock_client._send.assert_called_with(ANY, expected_data1)
+        handler.connection.incr.assert_called_with(*expected_data1)
+        handler.connection.send.assert_called_with()
 
         handler.process(metric2)
-        mock_client._send.assert_called_with(ANY, expected_data2)
+        handler.connection.incr.assert_called_with(*expected_data2)
+        handler.connection.send.assert_called_with()

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps = pyutmp
        beanstalkc
        bernhard
        kitchen
-       python-statsd
+       statsd
        PyYAML
        boto
        docker-py


### PR DESCRIPTION
first step to stop support for python-statsd
(https://github.com/WoLpH/python-statsd) in place of
(https://github.com/jsocol/pystatsd)