### PR TITLE
Feature/postgres collector auth with pgpass

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -36,6 +36,8 @@ class PostgresqlCollector(diamond.collector.Collector):
             'user': 'Username',
             'password': 'Password',
             'port': 'Port number',
+            'password_provider': "Whether to auth with supplied password or"
+            " .pgpass file  <password|pgpass>",
             'sslmode': 'Whether to use SSL - <disable|allow|require|...>',
             'underscore': 'Convert _ to .',
             'extended': 'Enable collection of extended database stats.',
@@ -59,6 +61,7 @@ class PostgresqlCollector(diamond.collector.Collector):
             'user': 'postgres',
             'password': 'postgres',
             'port': 5432,
+            'password_provider': 'password',
             'sslmode': 'disable',
             'underscore': False,
             'extended': False,
@@ -160,6 +163,10 @@ class PostgresqlCollector(diamond.collector.Collector):
             conn_args['database'] = database
         else:
             conn_args['database'] = 'postgres'
+
+        # libpq will use ~/.pgpass only if no password supplied
+        if self.config['password_provider'] == 'pgpass':
+            del conn_args['password']
 
         try:
             conn = psycopg2.connect(**conn_args)

--- a/src/collectors/postgres/test/testpostgres.py
+++ b/src/collectors/postgres/test/testpostgres.py
@@ -5,6 +5,7 @@
 from test import CollectorTestCase
 from test import get_collector_config
 
+from mock import patch, Mock
 from postgres import PostgresqlCollector
 
 
@@ -19,3 +20,43 @@ class TestPostgresqlCollector(CollectorTestCase):
 
     def test_import(self):
         self.assertTrue(PostgresqlCollector)
+
+    @patch('postgres.psycopg2')
+    def test_connect_with_password(self, psycopg2_mock):
+        conn_mock = Mock()
+        psycopg2_mock.connect.return_value = conn_mock
+
+        ret = self.collector._connect('test_db')
+
+        self.assertTrue(conn_mock.set_isolation_level.called)
+        self.assertEqual(ret, conn_mock)
+        psycopg2_mock.connect.assert_called_once_with(
+            database='test_db', host='localhost', password='postgres',
+            port=5432, sslmode='disable', user='postgres'
+        )
+
+    @patch('postgres.psycopg2')
+    def test_connect_with_pgpass(self, psycopg2_mock):
+        config = get_collector_config('PostgresqlCollector', {
+            'password_provider': 'pgpass'
+        })
+        self.collector = PostgresqlCollector(config, None)
+
+        conn_mock = Mock()
+        psycopg2_mock.connect.return_value = conn_mock
+
+        ret = self.collector._connect('test_db')
+
+        self.assertTrue(conn_mock.set_isolation_level.called)
+        self.assertEqual(ret, conn_mock)
+        psycopg2_mock.connect.assert_called_once_with(
+            database='test_db', host='localhost',
+            port=5432, sslmode='disable', user='postgres'
+        )
+
+    @patch('postgres.psycopg2')
+    def test_connect_error(self, psycopg2_mock):
+        psycopg2_mock.connect.side_effect = Exception('Some db exc')
+
+        with self.assertRaises(Exception):
+            self.collector._connect('test_db')


### PR DESCRIPTION
Option to authenticate to postgres with password stored in ~/.pgpass.
Added new config option `password_provider` that can take values:
- `password` - default, auth with supplied password from config
- `pgpass` - use ~/.pgpass

Using pgpass is implemented in libpq, pyscopg2 is based on, it only requires to not provide password.