### PR TITLE
Added ability to send Cloudwatch Metrics to AWS/AutoScaling namespace

### DIFF
--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -156,7 +156,7 @@ class cloudwatchHandler(Handler):
             self.cloudwatch = boto.ec2.cloudwatch.connect_to_region(
                 self.region)
             self.log.debug(
-                "CloudWatch: Succesfully Connected to CloudWatch at Region: %s",
+                "CloudWatch: Succesfully Connected to CloudWatch Region: %s",
                 self.region)
         except boto.exception.EC2ResponseError:
             self.log.error('CloudWatch: CloudWatch Exception Handler: ')
@@ -210,7 +210,9 @@ class cloudwatchHandler(Handler):
                 )
                 try:
                     if self.autoscaling:
-                        self.log.debug('Cloudwatch: Publishing metric to AutoScaling')
+                        self.log.debug(
+                            'Cloudwatch: Publishing metric to AutoScaling'
+                        )
                         self.cloudwatch.put_metric_data(
                             str(rule['namespace']),
                             str(rule['name']),

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -189,7 +189,9 @@ class cloudwatchHandler(Handler):
 
         try:
             if self.config['autoscaling']:
-                instances = self.ec2.get_only_instances(["%s" % self.instance_id])
+                instances = self.ec2.get_only_instances([
+                    "%s" % self.instance_id
+                ])
                 inst = instances[0]
                 self.log.debug(inst.tags['aws:autoscaling:groupName'])
                 autoscaling_group = inst.tags['aws:autoscaling:groupName']

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -50,7 +50,6 @@ except ImportError:
     boto = None
 
 from json import load
-import os
 
 class InstanceTypeError(Exception):
     """
@@ -89,12 +88,12 @@ class cloudwatchHandler(Handler):
         try:
             self.cached_aws_info = self.config['awsinfo']
             self.log.debug("Found cached AWS Instance details, I won't call AWS for them")
-        except KeyError as e:
+        except KeyError:
             self.log.debug("Proceeding by calling AWS for instance details")
 
         if self.cached_aws_info:
-            with open(self.config['awsinfo'], 'r') as f:
-                info = load(f)
+            with open(self.config['awsinfo'], 'r') as awsinfo:
+                info = load(awsinfo)
                 self.instance_id = info['instance']
                 self.autoscaling_group_name = info['autoscaling_group_name']
                 self.region = info['region']

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -51,6 +51,7 @@ except ImportError:
 
 from json import load
 
+
 class InstanceTypeError(Exception):
     """
     This is thrown when the user tries to publish a metric to the
@@ -92,8 +93,8 @@ class cloudwatchHandler(Handler):
             self.log.debug("Proceeding by calling AWS for instance details")
 
         if self.cached_aws_info:
-            with open(self.config['awsinfo'], 'r') as awsinfo:
-                info = load(awsinfo)
+            with open(self.config['awsinfo'], 'r') as f:
+                info = load(f)
                 self.instance_id = info['instance']
                 self.autoscaling_group_name = info['autoscaling_group_name']
                 self.region = info['region']
@@ -212,6 +213,8 @@ class cloudwatchHandler(Handler):
         collector = str(metric.getCollectorPath())
         metricname = str(metric.getMetricPath())
         timestamp = datetime.datetime.fromtimestamp(metric.timestamp)
+
+        autoscaling_group = None
 
         try:
             if self.config['autoscaling']:

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -210,7 +210,7 @@ class cloudwatchHandler(Handler):
                 )
                 try:
                     if self.autoscaling:
-                        self.log.debug('Cloudwatch: Publishing metric to autoscaling')
+                        self.log.debug('Cloudwatch: Publishing metric to AutoScaling')
                         self.cloudwatch.put_metric_data(
                             str(rule['namespace']),
                             str(rule['name']),
@@ -235,7 +235,7 @@ class cloudwatchHandler(Handler):
                 except AttributeError, e:
                     self.log.error(
                         "CloudWatch: Failed publishing - %s ", str(e))
-                except Exception as e:  # Rough connection re-try logic.
+                except Exception:  # Rough connection re-try logic.
                     self.log.error(
                         "CloudWatch: Failed publishing - %s ",
                         str(sys.exc_info()[0]))

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -88,7 +88,9 @@ class cloudwatchHandler(Handler):
 
         try:
             self.cached_aws_info = self.config['awsinfo']
-            self.log.debug("Found cached AWS Instance details, I won't call AWS for them")
+            self.log.debug(
+                "Found cached AWS Instance details, I won't call AWS for them"
+            )
         except KeyError:
             self.log.debug("Proceeding by calling AWS for instance details")
 
@@ -219,13 +221,19 @@ class cloudwatchHandler(Handler):
         try:
             if self.config['autoscaling']:
                 if not self.autoscaling_group_name:
-                    self.log.debug("Grabbing AutoScaling group name from Boto")
-                    instances = self.ec2.get_only_instances(["%s" % self.instance_id])
+                    self.log.debug(
+                        "Grabbing AutoScaling group name from Boto"
+                    )
+                    instances = self.ec2.get_only_instances([
+                        "%s" % self.instance_id
+                    ])
                     inst = instances[0]
                     self.log.debug(inst.tags['aws:autoscaling:groupName'])
                     autoscaling_group = inst.tags['aws:autoscaling:groupName']
                 else:
-                    self.log.debug("AutoScaling group name read from cache, sending to it.")
+                    self.log.debug(
+                        "AutoScaling group name read from cache, sending to it."
+                    )
                     autoscaling_group = self.autoscaling_group_name
         except KeyError:
             raise InstanceTypeError(


### PR DESCRIPTION
This patch affects the Cloudwatch Handler. It adds the ability to send metrics to the AWS/AutoScaling namespace by defining the AWS/AutoScaling Namespace, and grabbing the "aws:autoscaling:groupName" from the Instance Tags.

The original Cloudwatch handler automatically assigned all metrics to the instance that they were sent from. This adds the ability to send any given metric to an AutoScaling group as well, as a metric for the user to scale on.
