### PR TITLE
Ignore warnings for lsof -bu

### DIFF
--- a/src/collectors/filestat/filestat.py
+++ b/src/collectors/filestat/filestat.py
@@ -236,7 +236,7 @@ class FilestatCollector(diamond.collector.Collector):
         d = {}
         for u in users:
             d[u] = {}
-            tmp = os.popen("lsof -bu %s | awk '{ print $5 }'" % (
+            tmp = os.popen("lsof -wbu %s | awk '{ print $5 }'" % (
                 u)).read().split()
             for t in types:
                 d[u][t] = tmp.count(t)


### PR DESCRIPTION
Suppress warnings when running `lsof -bu <user>`. 

Per the man pages

```
-b	causes lsof to avoid  kernel  functions	 that  might  block  -
		lstat(2), readlink(2), and stat(2).
```

Unfortunately, this causes warnings to be printed stdout, which is undesirable.

```
lsof: avoiding readlink(/): -b was specified.
lsof: avoiding stat(/): -b was specified.
lsof: WARNING: can't stat() rootfs file system /
      Output information may be incomplete.
```