### PR TITLE
Missing %s for string interpolation

### DIFF
--- a/src/collectors/mesos_cgroup/mesos_cgroup.py
+++ b/src/collectors/mesos_cgroup/mesos_cgroup.py
@@ -82,7 +82,7 @@ class MesosCGroupCollector(diamond.collector.Collector):
                 task_id = os.path.join(aspect_path, task_id)
 
                 if aspect == "cpuacct":
-                    with open(os.path.join(task_id, "%.usage" % aspect)) as f:
+                    with open(os.path.join(task_id, "%s.usage" % aspect)) as f:
                         value = f.readline()
                         self.publish(
                             self.clean_up(


### PR DESCRIPTION
Without the `s` it was expecting a number and caused it to crash with:

```
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/diamond/utils/scheduler.py", line 73, in collector_process
    collector._run()
  File "/usr/lib/pymodules/python2.7/diamond/collector.py", line 472, in _run
    self.collect()
  File "/usr/share/diamond/collectors/mesos_cgroup/mesos_cgroup.py", line 85, in collect
    with open(os.path.join(task_id, "%.usage" % aspect)) as f:
TypeError: %u format: a number is required, not str
~
```