### PR TITLE
Removed '.' prefix from metric_name

### DIFF
--- a/src/collectors/nfsd/nfsd.py
+++ b/src/collectors/nfsd/nfsd.py
@@ -190,7 +190,7 @@ class NfsdCollector(diamond.collector.Collector):
             file.close()
 
             for stat in results.keys():
-                metric_name = '.' + stat
+                metric_name = stat
                 metric_value = long(float(results[stat]))
                 metric_value = self.derivative(metric_name, metric_value)
                 self.publish(metric_name, metric_value)


### PR DESCRIPTION
Removed '.' prefix from metric_name which causes the metric path to have an empty node.
