### PR TITLE
Fix RabbitMQ collector with recent change in rabbitmq-management

### DIFF
--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -238,13 +238,21 @@ class RabbitMQCollector(diamond.collector.Collector):
         if isinstance(value, dict):
             for new_key in value:
                 self._publish_metrics(name, keys, new_key, value)
-        elif isinstance(value, (float, int, long)):
+        elif isinstance(value, (float, int, long, type(None))):
             joined_keys = '.'.join(keys)
+
             if name:
                 publish_key = '{0}.{1}'.format(name, joined_keys)
             else:
                 publish_key = joined_keys
+
             if isinstance(value, bool):
                 value = int(value)
+
+            if isinstance(value, type(None)):
+                if "consumer_utilisation" in publish_key:
+                    value = 0
+                else:
+                    return False
 
             self.publish(publish_key, value)


### PR DESCRIPTION
Due to https://github.com/rabbitmq/rabbitmq-management/pull/74 and https://github.com/rabbitmq/rabbitmq-management/issues/100

`consumer_utilisation` used to be exposed as `""` when empty, its now `null` / `None` - causing it to no be emitted with a default value of `0` no more

I applied this fix for our own code, but I'm not a python developer, so there may be a more smooth way to do it
