### PR TITLE
Setup.py: Fix major version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,10 @@ else:
                                ['bin/init.d/diamond']))
             data_files.append(('/var/log/diamond',
                                ['.keep']))
-            if distro_major_version >= '7' and not distro == 'debian':
+            if distro_major_version >= 7 and not distro == 'debian':
                 data_files.append(('/usr/lib/systemd/system',
                                    ['rpm/systemd/diamond.service']))
-            elif distro_major_version >= '6' and not distro == 'debian':
+            elif distro_major_version >= 6 and not distro == 'debian':
                 data_files.append(('/etc/init',
                                    ['rpm/upstart/diamond.conf']))
 


### PR DESCRIPTION
On Fedora 20, `diamond.service` wasn't included in the RPM
because `distro_major_version >= '7'` evaluates to false. Changing
`'7'` to an integer fixes this.

Note: This changeset was originally made in BrightcoveOS/Diamond#787 but appears to have gotten lost in the repository's transition to python-diamond/Diamond.