### PR TITLE
Ensure the timestamp passed to boto is UTC.

### DIFF
--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -168,7 +168,7 @@ class cloudwatchHandler(Handler):
 
         collector = str(metric.getCollectorPath())
         metricname = str(metric.getMetricPath())
-        timestamp = datetime.datetime.fromtimestamp(metric.timestamp)
+        timestamp = datetime.datetime.utcfromtimestamp(metric.timestamp)
 
         # Send the data as ......
 


### PR DESCRIPTION
I have updated the timestamp to be based on UTC datetime which seems to be required by the boto `put_metric_data` call. 

I am very rusty with python so any suggestions are welcome.

The error I was getting is as follows.

```
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/diamond/handler/cloudwatch.py", line 200, in process
    {'InstanceID': self.instance_id})
  File "/usr/lib/python2.6/site-packages/boto/ec2/cloudwatch/__init__.py", line 335, in put_metric_data
    return self.get_status('PutMetricData', params, verb="POST")
  File "/usr/lib/python2.6/site-packages/boto/connection.py", line 1223, in get_status
    raise self.ResponseError(response.status, response.reason, body)
BotoServerError: BotoServerError: 400 Bad Request
<ErrorResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
  <Error>
    <Type>Sender</Type>
    <Code>InvalidParameterValue</Code>
    <Message>The parameter MetricData.member.1.Timestamp must specify a time within the past two weeks.</Message>
  </Error>
  <RequestId>dfeb21b1-ba8a-11e5-9d59-1b26dbc49fdd</RequestId>
</ErrorResponse>
```

Python version is `Python 2.6.6`
Operating system is `Red Hat Enterprise Linux Server release 6.6`
