### PR TITLE
Jolokia collector fixes

### DIFF
--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -50,6 +50,7 @@ an mbean.
 
 import diamond.collector
 import base64
+from contextlib import closing
 import json
 import re
 import urllib
@@ -151,8 +152,12 @@ class JolokiaCollector(diamond.collector.Collector):
                                          self.config['port'],
                                          self.config['path'],
                                          self.LIST_URL)
-            response = urllib2.urlopen(self._create_request(url))
-            return self.read_json(response)
+            # need some time to process the downloaded metrics, so that's why
+            # timeout is lower than the interval.
+            timeout = max(2, float(self.config['interval']) * 2 / 3)
+            with closing(urllib2.urlopen(self._create_request(url),
+                                         timeout=timeout)) as response:
+                return self.read_json(response)
         except (urllib2.HTTPError, ValueError):
             self.log.error('Unable to read JSON response.')
             return {}
@@ -164,8 +169,12 @@ class JolokiaCollector(diamond.collector.Collector):
                                          self.config['port'],
                                          self.config['path'],
                                          url_path)
-            response = urllib2.urlopen(self._create_request(url))
-            return self.read_json(response)
+            # need some time to process the downloaded metrics, so that's why
+            # timeout is lower than the interval.
+            timeout = max(2, float(self.config['interval']) * 2 / 3)
+            with closing(urllib2.urlopen(self._create_request(url),
+                                         timeout=timeout)) as response:
+                return self.read_json(response)
         except (urllib2.HTTPError, ValueError):
             self.log.error('Unable to read JSON response.')
             return {}

--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -86,7 +86,7 @@ class JolokiaCollector(diamond.collector.Collector):
             'port': 'Port',
             'rewrite': "This sub-section of the config contains pairs of"
                        " from-to regex rewrites.",
-            'path': 'Path to jolokia.  typically "jmx" or "jolokia"',
+            'path': 'Path component of the reported metrics.',
             # https://github.com/rhuss/jolokia/blob/959424888a82abc2b1906c60547cd4df280f3b71/client/java/src/main/java/org/jolokia/client/request/J4pQueryParameter.java#L68
             'use_canonical_names': 'Whether property keys of ObjectNames'
                                    ' should be ordered in the canonical way'
@@ -96,6 +96,8 @@ class JolokiaCollector(diamond.collector.Collector):
                                    ' alphabetical sorted) is used or "False"'
                                    ' for getting the keys as registered.'
                                    ' Default is "True',
+            'jolokia_path': 'Path to jolokia.  typically "jmx" or "jolokia".'
+                            ' Defaults to the value of "path" variable.',
         })
         return config_help
 
@@ -106,6 +108,7 @@ class JolokiaCollector(diamond.collector.Collector):
             'regex': False,
             'rewrite': [],
             'path': 'jolokia',
+            'jolokia_path': None,
             'username': None,
             'password': None,
             'host': 'localhost',
@@ -141,6 +144,11 @@ class JolokiaCollector(diamond.collector.Collector):
                     self.domains.append(domain.strip())
             elif isinstance(self.config['domains'], list):
                 self.domains = self.config['domains']
+
+        if self.config['jolokia_path'] is not None:
+            self.jolokia_path = self.config['jolokia_path']
+        else:
+            self.jolokia_path = self.config['path']
 
     def _get_domains(self):
         # if not set it __init__
@@ -198,7 +206,7 @@ class JolokiaCollector(diamond.collector.Collector):
             # and are dummy values.
             url = "http://%s:%s/%s%s?maxDepth=1" % (self.config['host'],
                                                     self.config['port'],
-                                                    self.config['path'],
+                                                    self.jolokia_path,
                                                     self.LIST_URL)
             # need some time to process the downloaded metrics, so that's why
             # timeout is lower than the interval.
@@ -220,7 +228,7 @@ class JolokiaCollector(diamond.collector.Collector):
             })
             url = "http://%s:%s/%s%s" % (self.config['host'],
                                          self.config['port'],
-                                         self.config['path'],
+                                         self.jolokia_path,
                                          url_path)
             # need some time to process the downloaded metrics, so that's why
             # timeout is lower than the interval.

--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -118,7 +118,6 @@ class JolokiaCollector(diamond.collector.Collector):
     def __init__(self, *args, **kwargs):
         super(JolokiaCollector, self).__init__(*args, **kwargs)
         self.mbeans = []
-        self.rewrite = {}
         if isinstance(self.config['mbeans'], basestring):
             for mbean in self.config['mbeans'].split('|'):
                 self.mbeans.append(mbean.strip())
@@ -144,12 +143,10 @@ class JolokiaCollector(diamond.collector.Collector):
             elif isinstance(self.config['domains_to_check'], list):
                 self.domains = self.config['domains_to_check']
 
-        self._get_domains()
-
     def _get_domains(self):
         # if not set it __init__
         if not self.domains:
-            listing = self.list_request()
+            listing = self._list_request()
             try:
                 if listing['status'] == 200:
                     self.domains = listing['value'].keys()
@@ -261,7 +258,7 @@ class JolokiaCollector(diamond.collector.Collector):
         return req
 
     def clean_up(self, text):
-        for (oldregex, newstr) in self.rewrite.items():
+        for (oldregex, newstr) in self.rewrite:
             text = oldregex.sub(newstr, text)
         return text
 

--- a/src/collectors/jolokia/test/testjolokia.py
+++ b/src/collectors/jolokia/test/testjolokia.py
@@ -7,6 +7,7 @@ from test import get_collector_config
 from test import unittest
 from mock import Mock
 from mock import patch
+import re
 
 from diamond.collector import Collector
 
@@ -27,7 +28,7 @@ class TestJolokiaCollector(CollectorTestCase):
 
     @patch.object(Collector, 'publish')
     def test_should_work_with_real_data(self, publish_mock):
-        def se(url):
+        def se(url, timeout=0):
             if url == 'http://localhost:8778/jolokia/list':
                 return self.getFixture('listing')
             else:
@@ -46,7 +47,7 @@ class TestJolokiaCollector(CollectorTestCase):
 
     @patch.object(Collector, 'publish')
     def test_real_data_with_rewrite(self, publish_mock):
-        def se(url):
+        def se(url, timeout=0):
             if url == 'http://localhost:8778/jolokia/list':
                 return self.getFixture('listing')
             else:
@@ -54,7 +55,11 @@ class TestJolokiaCollector(CollectorTestCase):
         patch_urlopen = patch('urllib2.urlopen', Mock(side_effect=se))
 
         patch_urlopen.start()
-        self.collector.rewrite = {'memoryUsage': 'memUsed', '.*\.init': ''}
+        rewrite = [
+            (re.compile('memoryUsage'), 'memUsed'),
+            (re.compile('.*\.init'), ''),
+        ]
+        self.collector.rewrite.extend(rewrite)
         self.collector.collect()
         patch_urlopen.stop()
 
@@ -80,7 +85,7 @@ class TestJolokiaCollector(CollectorTestCase):
 
     @patch.object(Collector, 'publish')
     def test_should_skip_when_mbean_request_fails(self, publish_mock):
-        def se(url):
+        def se(url, timeout=0):
             if url == 'http://localhost:8778/jolokia/list':
                 return self.getFixture('listing_with_bad_mbean')
             elif url == ('http://localhost:8778/jolokia/?ignoreErrors=true'

--- a/src/collectors/jolokia/test/testjolokia.py
+++ b/src/collectors/jolokia/test/testjolokia.py
@@ -106,9 +106,9 @@ class TestJolokiaCollector(CollectorTestCase):
         self.assertPublishedMany(publish_mock, metrics)
 
     def test_should_escape_jolokia_domains(self):
-        domain_with_slash = self.collector.escape_domain('some/domain')
-        domain_with_bang = self.collector.escape_domain('some!domain')
-        domain_with_quote = self.collector.escape_domain('some"domain')
+        domain_with_slash = self.collector._escape_domain('some/domain')
+        domain_with_bang = self.collector._escape_domain('some!domain')
+        domain_with_quote = self.collector._escape_domain('some"domain')
         self.assertEqual(domain_with_slash, 'some%21/domain')
         self.assertEqual(domain_with_bang, 'some%21%21domain')
         self.assertEqual(domain_with_quote, 'some%21%22domain')


### PR DESCRIPTION
We have encountered some problems with the Jolokia collector frequently timing out. The root cause was Jolokia's degraded performance when a connection wasn't closed (probably caused by signal in Diamond's scheduler interrupting the `urllib2.urlopen` call).

This pull request fixes this root cause (by adding timeouts to HTTP requests) as well as some of the slowdowns (e.g. caches regular expressions and the list of JMX domains).