### PR TITLE
-add kafka consumer lag collector

### DIFF
--- a/src/collectors/kafka_consumer_lag/kafka_consumer_lag.py
+++ b/src/collectors/kafka_consumer_lag/kafka_consumer_lag.py
@@ -1,0 +1,81 @@
+# coding=utf-8
+
+"""
+The KafkaConsumerLagCollector collects consumer lag metrics
+using ConsumerOffsetChecker.
+
+#### Dependencies
+
+ * bin/kafka-run-class.sh kafka.tools.ConsumerOffsetChecker
+
+"""
+
+import diamond.collector
+
+
+class KafkaConsumerLagCollector(diamond.collector.ProcessCollector):
+
+    def get_default_config_help(self):
+        collector = super(KafkaConsumerLagCollector, self)
+        config_help = collector.get_default_config_help()
+        config_help.update({
+            'bin': 'The path to kafka-run-class.sh binary',
+            'topic': 'Comma-separated list of consumer topics.',
+            'zookeeper': 'ZooKeeper connect string.',
+            'consumer_groups': 'Consumer groups'
+        })
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings
+        """
+        config = super(KafkaConsumerLagCollector, self).get_default_config()
+        config.update({
+            'path': 'kafka.ConsumerLag',
+            'bin': '/opt/kafka/bin/kafka-run-class.sh',
+            'zookeeper': 'localhost:2181'
+        })
+        return config
+
+    def collect(self):
+        zookeeper = ','.join(self.config.get('zookeeper'))
+        consumer_groups = self.config.get('consumer_groups')
+        topic = self.config.get('topic')
+        cluster_name = '-'.join(zookeeper.split('/')[1:]).replace('-', '_')
+
+        for consumer_group in consumer_groups:
+            try:
+                cmd = [
+                    'kafka.tools.ConsumerOffsetChecker',
+                    '--group',
+                    consumer_group,
+                    '--zookeeper',
+                    zookeeper
+                    ]
+
+                if topic:
+                    cmd += '--topic %s' % topic
+
+                raw_output = self.run_command(cmd)
+                if raw_output is None:
+                    return
+
+                for i, output in enumerate(raw_output[0].split('\n')):
+                    if i == 0:
+                        continue
+
+                    items = output.strip().split(' ')
+                    metrics = [item for item in items if item]
+
+                    if not metrics:
+                        continue
+
+                    prefix_keys = metrics[:3]
+                    value = float(metrics[5])
+
+                    if cluster_name:
+                        prefix_keys.insert(0, cluster_name)
+                    self.publish('.'.join(prefix_keys), value)
+            except Exception as e:
+                self.log.error(e)

--- a/src/collectors/kafka_consumer_lag/test/fixtures/consumer_lag_check
+++ b/src/collectors/kafka_consumer_lag/test/fixtures/consumer_lag_check
@@ -1,0 +1,12 @@
+Group           Topic                          Pid Offset          logSize         Lag             Owner
+stage_nginx_access nginx_access                   0   123305117       123305117       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   1   131335441       131335443       2               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   2   126961253       126961253       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   3   126639604       126639604       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   4   133458750       133458750       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   5   123259366       123259366       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   6   129250182       129250182       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   7   129216099       129216151       52              stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   8   125522947       125522947       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   9   137825984       137825984       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0
+stage_nginx_access nginx_access                   10  119944751       119944751       0               stage_nginx_access_logstash-01-1453252639637-68eb3e58-0

--- a/src/collectors/kafka_consumer_lag/test/testkafka_consumer_lag.py
+++ b/src/collectors/kafka_consumer_lag/test/testkafka_consumer_lag.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+# coding=utf-8
+##########################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from mock import patch, Mock
+
+from diamond.collector import Collector
+from kafka_consumer_lag import KafkaConsumerLagCollector
+
+##########################################################################
+
+
+class TestKafkaConsumerLagCollector(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('KafkaConsumerLagCollector', {
+            'consumer_groups': ['test_group']
+        })
+
+        self.collector = KafkaConsumerLagCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(KafkaConsumerLagCollector)
+
+    @patch.object(Collector, 'publish')
+    def test_should_publish_gpu_stat(self, publish_mock):
+        output_mock = Mock(
+            return_value=(self.getFixture('consumer_lag_check').getvalue(), '')
+        )
+        collector_mock = patch.object(
+            KafkaConsumerLagCollector,
+            'run_command',
+            output_mock
+        )
+
+        collector_mock.start()
+        self.collector.collect()
+        collector_mock.stop()
+
+        metrics = {
+            'stage_nginx_access.nginx_access.0': 0,
+            'stage_nginx_access.nginx_access.1': 2,
+            'stage_nginx_access.nginx_access.2': 0,
+            'stage_nginx_access.nginx_access.3': 0,
+            'stage_nginx_access.nginx_access.4': 0,
+            'stage_nginx_access.nginx_access.5': 0,
+            'stage_nginx_access.nginx_access.6': 0,
+            'stage_nginx_access.nginx_access.7': 52,
+            'stage_nginx_access.nginx_access.8': 0,
+            'stage_nginx_access.nginx_access.9': 0,
+            'stage_nginx_access.nginx_access.10': 0
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)\
+
+
+    @patch.object(Collector, 'publish')
+    def test_should_publish_gpu_stat(self, publish_mock):
+        self.collector.config.update({
+            'zookeeper':
+                ['192.168.1.101:2181', '192.168.1.102:2181/dev/test-01']
+        })
+        output_mock = Mock(
+            return_value=(self.getFixture('consumer_lag_check').getvalue(), '')
+        )
+        collector_mock = patch.object(
+            KafkaConsumerLagCollector,
+            'run_command',
+            output_mock
+        )
+
+        collector_mock.start()
+        self.collector.collect()
+        collector_mock.stop()
+
+        metrics = {
+            'dev_test_01.stage_nginx_access.nginx_access.0': 0,
+            'dev_test_01.stage_nginx_access.nginx_access.1': 2,
+            'dev_test_01.stage_nginx_access.nginx_access.2': 0,
+            'dev_test_01.stage_nginx_access.nginx_access.3': 0,
+            'dev_test_01.stage_nginx_access.nginx_access.4': 0,
+            'dev_test_01.stage_nginx_access.nginx_access.5': 0,
+            'dev_test_01.stage_nginx_access.nginx_access.6': 0,
+            'dev_test_01.stage_nginx_access.nginx_access.7': 52,
+            'dev_test_01.stage_nginx_access.nginx_access.8': 0,
+            'dev_test_01.stage_nginx_access.nginx_access.9': 0,
+            'dev_test_01.stage_nginx_access.nginx_access.10': 0
+        }
+        self.assertPublishedMany(publish_mock, metrics)


### PR DESCRIPTION
This collector is going to collect Kafka consumer lag metrics using `bin/kafka-run-class.sh kafka.tools.ConsumerOffsetChecker`
