### PR TITLE
Allow SNMP collector to address different communities

### DIFF
--- a/src/collectors/snmp/snmp.py
+++ b/src/collectors/snmp/snmp.py
@@ -75,7 +75,9 @@ class SNMPCollector(diamond.collector.Collector):
         host = socket.gethostbyname(host)
 
         # Assemble SNMP Auth Data
-        snmpAuthData = cmdgen.CommunityData('agent-{0}'.format(community), community)
+        snmpAuthData = cmdgen.CommunityData(
+            'agent-{0}'.format(community),
+            community)
 
         # Assemble SNMP Transport Data
         snmpTransportData = cmdgen.UdpTransportTarget(
@@ -109,7 +111,9 @@ class SNMPCollector(diamond.collector.Collector):
         host = socket.gethostbyname(host)
 
         # Assemble SNMP Auth Data
-        snmpAuthData = cmdgen.CommunityData('agent-{0}'.format(community), community)
+        snmpAuthData = cmdgen.CommunityData(
+            'agent-{0}'.format(community),
+            community)
 
         # Assemble SNMP Transport Data
         snmpTransportData = cmdgen.UdpTransportTarget(

--- a/src/collectors/snmp/snmp.py
+++ b/src/collectors/snmp/snmp.py
@@ -75,7 +75,7 @@ class SNMPCollector(diamond.collector.Collector):
         host = socket.gethostbyname(host)
 
         # Assemble SNMP Auth Data
-        snmpAuthData = cmdgen.CommunityData('agent', community)
+        snmpAuthData = cmdgen.CommunityData('agent-{0}'.format(community), community)
 
         # Assemble SNMP Transport Data
         snmpTransportData = cmdgen.UdpTransportTarget(
@@ -109,7 +109,7 @@ class SNMPCollector(diamond.collector.Collector):
         host = socket.gethostbyname(host)
 
         # Assemble SNMP Auth Data
-        snmpAuthData = cmdgen.CommunityData('agent', community)
+        snmpAuthData = cmdgen.CommunityData('agent-{0}'.format(community), community)
 
         # Assemble SNMP Transport Data
         snmpTransportData = cmdgen.UdpTransportTarget(


### PR DESCRIPTION
The SNMP collector uses the constant string 'agent' as the index for its CommunityData object.  This means multiple SNMP collectors will conflict, as second and subsequent collectors will use the same community name as the first collector, even if the diamond configuration specifies a different community.

Instead, include the community name in the index, so that each community has a unique index.
