### PR TITLE
haproxy.py: Support unix socket collection

### DIFF
--- a/src/collectors/haproxy/test/testhaproxy.py
+++ b/src/collectors/haproxy/test/testhaproxy.py
@@ -45,6 +45,42 @@ class TestHAProxyCollector(CollectorTestCase):
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
+    def test_should_work_with_unix_socket_code_path(self, publish_mock):
+        self.collector.config['method'] = 'unix'
+
+        class MockSocket():
+            def __init__(*args, **kwargs):
+                self.connected = False
+                self.output_data = ''
+
+            def connect(*args, **kwargs):
+                self.connected = True
+
+            def send(obj, string, *args, **kwargs):
+                if not self.connected:
+                    raise Exception('MockSocket: Endpoint not connected.')
+                if string == 'show stat\n':
+                    self.output_data = self.getFixture('stats.csv').getvalue()
+
+            def recv(obj, bufsize, *args, **kwargs):
+                output_buffer = self.output_data[:bufsize]
+                self.output_data = self.output_data[bufsize:]
+                return output_buffer
+
+        patch_socket = patch('socket.socket', Mock(return_value=MockSocket()))
+
+        patch_socket.start()
+        self.collector.collect()
+        patch_socket.stop()
+
+        metrics = self.getPickledResults('real_data.pkl')
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
     def test_should_work_with_real_data_and_ignore_servers(self, publish_mock):
         self.collector.config['ignore_servers'] = True
 


### PR DESCRIPTION
In addition to HTTP, HAProxy also exposes statistics through its
configurable admin UNIX domain socket, by use of the command 'show
stat'. This change enables support in the HAProxy collector for using
this for data collection.

To use this, set 'method' to 'unix' in the collector configuration, and
optionally set the socket path with the 'sock' option.

The default behaviour is left unchanged, as the 'method' option defaults
to 'http'.