### PR TITLE
Fix nfs space collection

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -41,8 +41,8 @@ class DiskSpaceCollector(diamond.collector.Collector):
                 "A list of regex patterns. Any filesystem" +
                 " matching any of these patterns will be excluded from disk" +
                 " space metrics collection",
-            'no_major_minor': "Don't rely on the major/minor numbers from an os.stat"
-            + " call on these filesystem types (e.g. nfs)",
+            'no_major_minor': "Don't rely on the major/minor numbers from" +
+                " an os.stat call on these filesystem types (e.g. nfs)",
         })
         return config_help
 

--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -166,7 +166,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
                         continue
                     elif fs_type in self.no_major_minor:
                         major = 0
-                        minor = len(results)
+                        minor = len(result)
 
                     result[(major, minor)] = {
                         'device': os.path.realpath(device),

--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -162,7 +162,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
                         continue
 
                     if (major, minor) in result \
-                            and mount_point not in self.no_major_minor:
+                            and fs_type not in self.no_major_minor:
                         continue
                     elif fs_type in self.no_major_minor:
                         major = 0

--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -164,7 +164,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
                     if (major, minor) in result \
                             and mount_point not in self.no_major_minor:
                         continue
-                    elif mount_point in self.no_major_minor:
+                    elif fs_type in self.no_major_minor:
                         major = 0
                         minor = len(results)
 

--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -164,7 +164,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
                     if (major, minor) in result \
                             and mount_point not in self.no_major_minor:
                         continue
-                    elif mountpoint in self.no_major_minor:
+                    elif mount_point in self.no_major_minor:
                         major = 0
                         minor = len(results)
 


### PR DESCRIPTION
Since nfs servers can have multiple mount points, using the major/minor os.stat returns on a system with multiple nfs mounts means we only actually get the stats from one of them. This change fixes that behavior.
