### PR TITLE
Added missing dependency for EL6/7 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ rpm: buildrpm
 buildrpm: sdist
 	./setup.py bdist_rpm \
 		--release=`ls dist/*.noarch.rpm | wc -l` \
-		--build-requires='python, python-configobj' \
-		--requires='python, python-configobj'
+		--build-requires='python, python-configobj, python-setuptools' \
+		--requires='python, python-configobj, python-setuptools'
 
 deb: builddeb
 

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -11,6 +11,7 @@ Installation
 - CentOS or Ubuntu
 - Python 2.4+
 - python-configobj
+- python-setuptools
 - [Python Psutil](http://code.google.com/p/psutil/) for non linux system metrics
 
 ### Unit Test Dependencies 


### PR DESCRIPTION
Diamond fails to start on machines without `python-setuptools` package.