### PR TITLE
varnish.py: Also count sessions closed with error

### DIFF
--- a/src/collectors/varnish/test/fixtures/4.0/varnish_stats
+++ b/src/collectors/varnish/test/fixtures/4.0/varnish_stats
@@ -67,6 +67,7 @@ MAIN.s_pipe_hdrbytes               0         0.00 Pipe request header bytes
 MAIN.s_pipe_in                     0         0.00 Piped bytes from client
 MAIN.s_pipe_out                    0         0.00 Piped bytes to client
 MAIN.sess_closed               58799        69.09 Session Closed
+MAIN.sess_closed_err            6412         7.53 Session Closed with error
 MAIN.sess_pipeline                53         0.06 Session Pipeline
 MAIN.sess_readahead               17         0.02 Session Read Ahead
 MAIN.sess_herd               4924320      5786.51 Session herd

--- a/src/collectors/varnish/test/testvarnish.py
+++ b/src/collectors/varnish/test/testvarnish.py
@@ -214,6 +214,7 @@ class TestVarnishCollector(CollectorTestCase):
             'MAIN.s_pipe_in': 0,
             'MAIN.s_pipe_out': 0,
             'MAIN.sess_closed': 58799,
+            'MAIN.sess_closed_err': 6412,
             'MAIN.sess_pipeline': 53,
             'MAIN.sess_readahead': 17,
             'MAIN.sess_herd': 4924320,

--- a/src/collectors/varnish/varnish.py
+++ b/src/collectors/varnish/varnish.py
@@ -69,6 +69,7 @@ class VarnishCollector(diamond.collector.Collector):
         'MAIN.s_req_hdrbytes', 'MAIN.s_req_bodybytes', 'MAIN.s_resp_hdrbytes',
         'MAIN.s_resp_bodybytes', 'MAIN.s_pipe_hdrbytes', 'MAIN.s_pipe_in',
         'MAIN.s_pipe_out', 'MAIN.sess_closed', 'MAIN.sess_pipeline',
+        'MAIN.sess_closed_err',
         'MAIN.sess_readahead', 'MAIN.sess_herd', 'MAIN.shm_records',
         'MAIN.shm_writes', 'MAIN.shm_flushes', 'MAIN.shm_cont',
         'MAIN.shm_cycles',


### PR DESCRIPTION
Specifically for Varnish 4.0, also collect varnishadm key
MAIN.sess_closed_err.