### PR TITLE
Changed stdout flag to add loggers from conf file and honor root log level

### DIFF
--- a/src/diamond/utils/log.py
+++ b/src/diamond/utils/log.py
@@ -35,27 +35,32 @@ class DebugFormatter(logging.Formatter):
 def setup_logging(configfile, stdout=False):
     log = logging.getLogger('diamond')
 
-    if stdout:
-        log.setLevel(logging.DEBUG)
-        streamHandler = logging.StreamHandler(sys.stdout)
-        streamHandler.setFormatter(DebugFormatter())
-        streamHandler.setLevel(logging.DEBUG)
-        log.addHandler(streamHandler)
-    else:
-        try:
-            if sys.version_info >= (2, 6):
-                logging.config.fileConfig(configfile,
-                                          disable_existing_loggers=False)
-            else:
-                # python <= 2.5 does not have disable_existing_loggers
-                # default was to always disable them, in our case we want to
-                # keep any logger created by handlers
-                logging.config.fileConfig(configfile)
-                for logger in logging.root.manager.loggerDict.values():
-                    logger.disabled = 0
-        except Exception, e:
-            sys.stderr.write("Error occurs when initialize logging: ")
-            sys.stderr.write(str(e))
-            sys.stderr.write(os.linesep)
+    try:
+        if sys.version_info >= (2, 6):
+            logging.config.fileConfig(configfile,
+                                      disable_existing_loggers=False)
+        else:
+            # python <= 2.5 does not have disable_existing_loggers
+            # default was to always disable them, in our case we want to
+            # keep any logger created by handlers
+            logging.config.fileConfig(configfile)
+            for logger in logging.root.manager.loggerDict.values():
+                logger.disabled = 0
+
+        # if the stdout flag is set, we use the log level of the root logger
+        # for logging to stdout, and keep all loggers defined in the conf file
+        if stdout:
+            rootLogLevel = logging.getLogger().getEffectiveLevel()
+
+            log.setLevel(rootLogLevel)
+            streamHandler = logging.StreamHandler(sys.stdout)
+            streamHandler.setFormatter(DebugFormatter())
+            streamHandler.setLevel(rootLogLevel)
+            log.addHandler(streamHandler)
+
+    except Exception, e:
+        sys.stderr.write("Error occurs when initialize logging: ")
+        sys.stderr.write(str(e))
+        sys.stderr.write(os.linesep)
 
     return log


### PR DESCRIPTION
This PR changes the behaviour of the  --log-stdout flag.

Previously, this flag disregarded any loggers defined in the config file, and created a new logger with DEBUG log level. 

This means, that if you use systemd, there's no way to set your log level to anything but DEBUG using the default rpm package: https://github.com/python-diamond/Diamond/blob/master/rpm/systemd/diamond.service#L5

With this PR, loggers defined in the conf file still get initialised, and the stdout loggers level will be the same as the root loggers.
