### PR TITLE
Fix globbing issue when metrics list is length 1

### DIFF
--- a/src/collectors/hadoop/hadoop.py
+++ b/src/collectors/hadoop/hadoop.py
@@ -44,7 +44,11 @@ class HadoopCollector(diamond.collector.Collector):
         return config
 
     def collect(self):
-        for pattern in self.config['metrics']:
+        metrics = self.config['metrics']
+        if not isinstance(metrics, list):
+            metrics = [str(metrics)]
+
+        for pattern in metrics:
             for filename in glob.glob(pattern):
                 self.collect_from(filename)
 

--- a/src/collectors/hbase/hbase.py
+++ b/src/collectors/hbase/hbase.py
@@ -34,7 +34,11 @@ class HBaseCollector(diamond.collector.Collector):
         return config
 
     def collect(self):
-        for pattern in self.config['metrics']:
+        metrics = self.config['metrics']
+        if not isinstance(metrics, list):
+            metrics = [str(metrics)]
+
+        for pattern in metrics:
             for filename in glob.glob(pattern):
                 self.collect_from(filename)
 


### PR DESCRIPTION
In the HBase and Hadoop collectors, if the `metrics` list of globbing patterns contains only one element, the loop in `collect()` will iterate over the characters in the string and glob over the individual characters, instead of globbing over the string as a whole. A check for if the `metrics` value is a `list` or not determines whether there is only one value provided or not.
