### PR TITLE
added option to replace slashes in rabbitmq queue or virtualhost names

### DIFF
--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -85,6 +85,8 @@ class RabbitMQCollector(diamond.collector.Collector):
             'password': 'Password',
             'replace_dot':
             'A value to replace dot in queue names and vhosts names by',
+            'replace_slash':
+            'A value to replace a slash in queue names and vhosts names by',
             'queues': 'Queues to publish. Leave empty to publish all.',
             'vhosts':
             'A list of vhosts and queues for which we want to collect',
@@ -107,6 +109,7 @@ class RabbitMQCollector(diamond.collector.Collector):
             'user': 'guest',
             'password': 'guest',
             'replace_dot': False,
+            'replace_slash': False,
             'queues_ignored': '',
             'cluster': False,
             'scheme': 'http',
@@ -192,6 +195,10 @@ class RabbitMQCollector(diamond.collector.Collector):
                     vhost_name = vhost_name.replace(
                         '.', self.config['replace_dot'])
 
+                if self.config['replace_slash']:
+                    vhost_name = vhost_name.replace(
+                        '/', self.config['replace_slash'])
+
                 queues = vhost_conf[vhost]
 
                 # Allow the use of a asterix to glob the queues, but replace
@@ -222,6 +229,10 @@ class RabbitMQCollector(diamond.collector.Collector):
                         if self.config['replace_dot']:
                             queue_name = queue_name.replace(
                                 '.', self.config['replace_dot'])
+
+                        if self.config['replace_slash']:
+                            queue_name = queue_name.replace(
+                                '/', self.config['replace_slash'])
 
                         name = '{0}.{1}'.format(prefix, queue_name)
 

--- a/src/collectors/rabbitmq/test/testrabbitmq.py
+++ b/src/collectors/rabbitmq/test/testrabbitmq.py
@@ -168,6 +168,75 @@ class TestRabbitMQCollector(CollectorTestCase):
 
         self.collector.config['replace_dot'] = False
 
+    @patch('rabbitmq.RabbitMQClient')
+    @patch.object(Collector, 'publish')
+    def test_opt_should_replace_slashes(self, publish_mock, client_mock):
+        self.collector.config['replace_slash'] = '_'
+        client = Mock()
+        queue_data = [{
+            'more_keys': {'nested_key': 1},
+            'key': 2,
+            'string': 'str',
+            'name': 'test/queue'
+        }, {
+            'name': 'ignored',
+            'more_keys': {'nested_key': 1},
+            'key': 2,
+            'string': 'str',
+        }]
+        overview_data = {
+            'node': 'rabbit@localhost',
+            'more_keys': {'nested_key': 3},
+            'key': 4,
+            'string': 'string',
+        }
+        node_health = {
+            'fd_used': 1,
+            'fd_total': 2,
+            'mem_used': 2,
+            'mem_limit': 4,
+            'sockets_used': 1,
+            'sockets_total': 2,
+            'disk_free_limit': 1,
+            'disk_free': 1,
+            'proc_used': 1,
+            'proc_total': 1,
+            'partitions': [],
+        }
+        client_mock.return_value = client
+        client.get_queues.return_value = queue_data
+        client.get_overview.return_value = overview_data
+        client.get_nodes.return_value = [1, 2, 3]
+        client.get_node.return_value = node_health
+
+        self.collector.collect()
+
+        metrics = {
+            'queues.test_queue.more_keys.nested_key': 1,
+            'queues.test_queue.key': 2,
+            'more_keys.nested_key': 3,
+            'key': 4,
+            'health.fd_used': 1,
+            'health.fd_total': 2,
+            'health.mem_used': 2,
+            'health.mem_limit': 4,
+            'health.sockets_used': 1,
+            'health.sockets_total': 2,
+            'health.disk_free_limit': 1,
+            'health.disk_free': 1,
+            'health.proc_used': 1,
+            'health.proc_total': 1,
+            'cluster.partitions': 0,
+            'cluster.nodes': 3
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+        self.collector.config['replace_slash'] = False
+
 ##########################################################################
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
RabbitMQ has a default vhost named "/" in certain setups.
This causes a problem with forwarding metrics to hostedGraphite. With grafana in hostedGraphite you can't select the metrics with / as vhost. This is solved by replacing / in the queue or vhost name by a custom string.