### PR TITLE
create tag on github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,5 +110,7 @@ distrotest:
 
 pypi: version sdist bdist_wheel
 	twine upload -s dist/*
+        git tag "v$(cat version.txt)"
+        git push --tags
 
 .PHONY: run watch config test docs sdist bdist bdist_wheel install rpm buildrpm deb sdeb builddeb buildsourcedeb ebuild buildebuild tar clean cleanws version reltest vertest distrotest pypi


### PR DESCRIPTION
make non-annotated tag and push it to github everytime you run the pipit target.

this will make it easier for people to map pypi versions to a particular commit hash.
