### PR TITLE
Load defaults before daemon check in diamond.init

### DIFF
--- a/debian/diamond.init
+++ b/debian/diamond.init
@@ -22,11 +22,11 @@ PIDFILE=/var/run/diamond.pid
 SCRIPTNAME=/etc/init.d/diamond
 CONF=/etc/diamond/diamond.conf
 
-# Exit if the package is not installed
-[ -x $DAEMON ] || exit 0
-
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Exit if the package is not installed
+[ -x $DAEMON ] || exit 0
 
 # Checking for a config file in place
 if [  ! -e $CONF ]; then


### PR DESCRIPTION
- DAEMON variable may need to be set differently, especially if
  installed via pip install diamond.
  
  By loading the defaults first, the DAEMON variable can be set in
  /etc/defaults.
