### PR TITLE
EventstoreProjectionCollector variable naming conflict fixed

### DIFF
--- a/src/collectors/eventstoreprojections/eventstoreprojections.py
+++ b/src/collectors/eventstoreprojections/eventstoreprojections.py
@@ -31,7 +31,7 @@ class EventstoreProjectionsCollector(diamond.collector.Collector):
         config_help.update({
             'path': "name of the metric in the metricpath",
             'protocol': 'protocol used to connect to eventstore',
-            'hostname': 'hostname of the eventstore instance',
+            'server': 'hostname or ipaddress of the eventstore server',
             'route': 'route in eventstore for projections',
             'port': 'tcp port where eventstore is listening',
             'headers': 'Header variable if needed',
@@ -48,7 +48,7 @@ class EventstoreProjectionsCollector(diamond.collector.Collector):
         default_config.update({
             'path': "eventstore",
             'protocol': 'http://',
-            'hostname': 'localhost',
+            'server': 'localhost',
             'route': '/projections/all-non-transient',
             'port': 2113,
             'headers': {'User-Agent': 'Diamond Eventstore metrics collector'},
@@ -86,7 +86,7 @@ class EventstoreProjectionsCollector(diamond.collector.Collector):
     def collect(self):
         eventstore_host = "%s%s:%s%s" % (
             self.config['protocol'],
-            self.config['hostname'],
+            self.config['server'],
             self.config['port'],
             self.config['route']
         )


### PR DESCRIPTION
When deploying the latest version of this collector I encountered that the hostname config option conflicts with the default hostname variable for collectors.

For example: I want the hostname to be polled to be 172.1.1.1, but the hostname to be reported in the metric to be the hostname of the docker container, like node_a_production.

without this PR, the metric looks like:

```
servers.172.1.1.1.eventstore.projections.participations-per-person-emitter-4.writePendingEventsAfterCheckpoint 0 1457950126
```

but I want it to look like:

```
servers.node_a_production.eventstore.projections.participations-per-person-emitter-4.writePendingEventsAfterCheckpoint 0 1457950126
```

I solved this by renaming hostname to server, although this is a less "correct" name, it does avoid the conflict with the existing hostname variable.
