### PR TITLE
uptading cluster health stats for elasticsearch 2x

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -194,6 +194,12 @@ class ElasticSearchCollector(diamond.collector.Collector):
                          result, ['unassigned_shards'])
         self._add_metric(metrics, 'cluster_health.shards.initializing',
                          result, ['initializing_shards'])
+        self._add_metric(metrics, 'cluster_health.shards.delayed_unassigned',
+                         result, ['delayed_unassigned_shards'])
+        self._add_metric(metrics, 'cluster_health.fetch.inflight',
+                         result, ['number_of_in_flight_fetch'])
+        self._add_metric(metrics, 'cluster_health.tasks.pending',
+                         result, ['number_of_pending_tasks'])
 
     def collect_instance_index_stats(self, host, port, metrics):
         result = self._get(host, port,


### PR DESCRIPTION
I just want add these cluster stats:

- delayed_unassigned_shards
- number_of_pending_tasks
- number_of_in_flight_fetch

to elasticsearch collector.