### PR TITLE
RabbitMQCollector: Add a query_individual_queues config option

### DIFF
--- a/docs/collectors/RabbitMQCollector.md
+++ b/docs/collectors/RabbitMQCollector.md
@@ -36,6 +36,7 @@ metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive w
 metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
 password | guest | Password | str
 queues |  | Queues to publish. Leave empty to publish all. | 
+query_individual_queues | False | If specific queues are set, query their metrics individually. When this is False, queue metrics will be queried in bulk and filtered, which can time out for vhosts with many queues. | bool
 queues_ignored |  | A list of queues or regexes for queue names not to report on. | str
 replace_dot | False | A value to replace dot in queue names and vhosts names by | bool
 user | guest | Username | str

--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -56,7 +56,7 @@ class RabbitMQClient(object):
 
     def get_vhost_names(self):
         return [i['name'] for i in self.get_all_vhosts()]
-    
+
     def get_queue(self, queue_name, vhost=None):
         path = 'queues'
         if vhost:
@@ -69,7 +69,7 @@ class RabbitMQClient(object):
         except Exception, e:
             self.log.error('Error querying queue %s: %s', (queue_name, e))
             return None
-    
+
     def get_queues(self, vhost=None):
         path = 'queues'
         if vhost:
@@ -166,19 +166,19 @@ class RabbitMQCollector(diamond.collector.Collector):
         except Exception, e:
             self.log.error('Couldnt connect to rabbitmq %s', e)
             return {}
-    
+
     def get_queue_metrics(self, client, vhost, queues):
         # Allow the use of a asterix to glob the queues, but replace
         # with a empty string to match how legacy config was.
         if queues == "*":
             queues = ""
         allowed_queues = queues.split()
-        
+
         matchers = []
         if self.config['queues_ignored']:
             for reg in self.config['queues_ignored'].split():
                 matchers.append(re.compile(reg))
-        
+
         if self.config['query_individual_queues']:
             for queue_name in allowed_queues:
                 if matchers and any(
@@ -197,7 +197,7 @@ class RabbitMQCollector(diamond.collector.Collector):
                         [m.match(queue['name']) for m in matchers]):
                     continue
                 yield queue
-        
+
     def collect(self):
         self.collect_health()
         try:

--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -66,8 +66,9 @@ class RabbitMQClient(object):
         try:
             queue = self.do_call(path)
             return queue or None
-        except Exception, e:
-            self.log.error('Error querying queue %s: %s', (queue_name, e))
+        except:
+            self.log.exception('Error querying queue %s/%s' %
+                (vhost, queue_name))
             return None
 
     def get_queues(self, vhost=None):
@@ -163,8 +164,8 @@ class RabbitMQCollector(diamond.collector.Collector):
                              len(node_data['partitions']))
                 content = client.get_nodes()
                 self.publish('cluster.nodes', len(content))
-        except Exception, e:
-            self.log.error('Couldnt connect to rabbitmq %s', e)
+        except:
+            self.log.exception('Couldnt connect to rabbitmq')
             return {}
 
     def get_queue_metrics(self, client, vhost, queues):
@@ -274,8 +275,8 @@ class RabbitMQCollector(diamond.collector.Collector):
             overview = client.get_overview()
             for key in overview:
                 self._publish_metrics('', [], key, overview)
-        except Exception, e:
-            self.log.error('An error occurred collecting from RabbitMQ, %s', e)
+        except:
+            self.log.exception('An error occurred collecting from RabbitMQ')
             return {}
 
     def _publish_metrics(self, name, prev_keys, key, data):

--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -67,15 +67,16 @@ class RabbitMQClient(object):
             queue = self.do_call(path)
             return queue or None
         except:
-            self.log.exception('Error querying queue %s/%s' %
-                (vhost, queue_name))
+            self.log.exception('Error querying queue %s/%s' % (
+                vhost, queue_name
+            ))
             return None
 
     def get_queues(self, vhost):
         path = 'queues'
         vhost = quote(vhost, '')
         path += '/%s' % vhost
-        
+
         try:
             queues = self.do_call(path)
             return queues or []
@@ -201,7 +202,7 @@ class RabbitMQCollector(diamond.collector.Collector):
                         [m.match(queue['name']) for m in matchers]):
                     continue
                 yield queue
-    
+
     def get_vhost_conf(self, vhost_names):
         legacy = False
         if 'vhosts' in self.config:
@@ -226,7 +227,7 @@ class RabbitMQCollector(diamond.collector.Collector):
                     vhost_conf[vhost] = vhost_conf['*']
             del vhost_conf["*"]
         return vhost_conf, legacy
-    
+
     def collect(self):
         self.collect_health()
         try:

--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -180,7 +180,7 @@ class RabbitMQCollector(diamond.collector.Collector):
             for reg in self.config['queues_ignored'].split():
                 matchers.append(re.compile(reg))
 
-        if self.config['query_individual_queues']:
+        if len(allowed_queues) and self.config['query_individual_queues']:
             for queue_name in allowed_queues:
                 if matchers and any(
                         [m.match(queue_name) for m in matchers]):

--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -66,9 +66,9 @@ class RabbitMQClient(object):
         try:
             queue = self.do_call(path)
             return queue or None
-        except:
-            self.log.exception('Error querying queue %s/%s' % (
-                vhost, queue_name
+        except Exception, e:
+            self.log.error('Error querying queue %s/%s: %s' % (
+                vhost, queue_name, e
             ))
             return None
 
@@ -80,8 +80,10 @@ class RabbitMQClient(object):
         try:
             queues = self.do_call(path)
             return queues or []
-        except:
-            self.log.exception('Error querying queues %s' % vhost)
+        except Exception, e:
+            self.log.error('Error querying queues %s: %s' % (
+                vhost, e
+            ))
             return []
 
     def get_overview(self):

--- a/src/collectors/rabbitmq/test/testrabbitmq.py
+++ b/src/collectors/rabbitmq/test/testrabbitmq.py
@@ -309,7 +309,7 @@ class TestRabbitMQCollector(CollectorTestCase):
         client.get_vhost_names.return_value = ['vhost1', 'vhost2']
 
         self.collector.collect()
-        
+
         client.get_queues.assert_not_called()
         client.get_nodes.assert_called_once_with()
         client.get_node.assert_called_once_with('rabbit@localhost')
@@ -320,7 +320,7 @@ class TestRabbitMQCollector(CollectorTestCase):
             call('vhost2', 'queue3'),
             call('vhost2', 'queue4'),
         ], any_order=True)
-        
+
         metrics = {
             'queues.queue1.key': 1,
             'queues.queue2.key': 2,
@@ -417,7 +417,7 @@ class TestRabbitMQCollector(CollectorTestCase):
         client.get_vhost_names.return_value = ['vhost1', 'vhost2']
 
         self.collector.collect()
-        
+
         client.get_queues.assert_not_called()
         client.get_nodes.assert_called_once_with()
         client.get_node.assert_called_once_with('rabbit@localhost')
@@ -428,7 +428,7 @@ class TestRabbitMQCollector(CollectorTestCase):
             call('vhost2', 'queue3'),
             call('vhost2', 'queue4'),
         ], any_order=True)
-        
+
         metrics = {
             'vhosts.vhost1.queues.queue1.key': 1,
             'vhosts.vhost1.queues.queue2.key': 2,

--- a/src/collectors/rabbitmq/test/testrabbitmq.py
+++ b/src/collectors/rabbitmq/test/testrabbitmq.py
@@ -281,7 +281,7 @@ class TestRabbitMQCollector(CollectorTestCase):
         client.get_node.return_value = node_health
 
         self.collector.collect()
-        
+
         client.get_queue.assert_called_once_with('test/queue', None)
         client.get_queues.assert_not_called()
 

--- a/src/collectors/rabbitmq/test/testrabbitmq.py
+++ b/src/collectors/rabbitmq/test/testrabbitmq.py
@@ -7,6 +7,7 @@ from test import get_collector_config
 from test import unittest
 from mock import Mock
 from mock import patch
+from mock import call
 
 from diamond.collector import Collector
 from rabbitmq import RabbitMQCollector
@@ -68,13 +69,15 @@ class TestRabbitMQCollector(CollectorTestCase):
         client.get_overview.return_value = overview_data
         client.get_nodes.return_value = [1, 2, 3]
         client.get_node.return_value = node_health
+        client.get_vhost_names.return_value = ['/']
 
         self.collector.collect()
 
-        client.get_queues.assert_called_once_with(None)
+        client.get_queues.assert_called_once_with('/')
         client.get_queue.assert_not_called()
         client.get_nodes.assert_called_once_with()
         client.get_node.assert_called_once_with('rabbit@localhost')
+        client.get_vhost_names.assert_called_once_with()
 
         metrics = {
             'queues.test_queue.more_keys.nested_key': 1,
@@ -140,6 +143,7 @@ class TestRabbitMQCollector(CollectorTestCase):
         client.get_overview.return_value = overview_data
         client.get_nodes.return_value = [1, 2, 3]
         client.get_node.return_value = node_health
+        client.get_vhost_names.return_value = ['/']
 
         self.collector.collect()
 
@@ -209,6 +213,7 @@ class TestRabbitMQCollector(CollectorTestCase):
         client.get_overview.return_value = overview_data
         client.get_nodes.return_value = [1, 2, 3]
         client.get_node.return_value = node_health
+        client.get_vhost_names.return_value = ['/']
 
         self.collector.collect()
 
@@ -240,26 +245,48 @@ class TestRabbitMQCollector(CollectorTestCase):
 
     @patch('rabbitmq.RabbitMQClient')
     @patch.object(Collector, 'publish')
-    def test_opt_query_individual_queues(self, publish_mock, client_mock):
+    def test_opt_individual_queues(self, publish_mock, client_mock):
         self.collector.config['query_individual_queues'] = True
-        self.collector.config['queues'] = 'test/queue'
+        self.collector.config['queues'] = 'queue1 queue2 queue3 queue4'
         client = Mock()
-        queue_data = [{
-            'more_keys': {'nested_key': 1},
-            'key': 2,
-            'string': 'str',
-            'name': 'test/queue'
-        }, {
-            'name': 'ignored',
-            'more_keys': {'nested_key': 1},
-            'key': 2,
-            'string': 'str',
-        }]
+        queue_data = {
+            'vhost1': {
+                'queue1': {
+                    'name': 'queue1',
+                    'key': 1,
+                    'string': 'str',
+                },
+                'queue2': {
+                    'name': 'queue2',
+                    'key': 2,
+                    'string': 'str',
+                },
+                'ignored': {
+                    'name': 'ignored',
+                    'key': 3,
+                    'string': 'str',
+                },
+            },
+            'vhost2': {
+                'queue3': {
+                    'name': 'queue3',
+                    'key': 4,
+                    'string': 'str',
+                },
+                'queue4': {
+                    'name': 'queue4',
+                    'key': 5,
+                    'string': 'str',
+                },
+                'ignored': {
+                    'name': 'ignored',
+                    'key': 6,
+                    'string': 'str',
+                }
+            }
+        }
         overview_data = {
             'node': 'rabbit@localhost',
-            'more_keys': {'nested_key': 3},
-            'key': 4,
-            'string': 'string',
         }
         node_health = {
             'fd_used': 1,
@@ -275,18 +302,159 @@ class TestRabbitMQCollector(CollectorTestCase):
             'partitions': [],
         }
         client_mock.return_value = client
-        client.get_queue.return_value = queue_data[0]
+        client.get_queue.side_effect = lambda v, q: queue_data.get(v).get(q)
         client.get_overview.return_value = overview_data
         client.get_nodes.return_value = [1, 2, 3]
         client.get_node.return_value = node_health
+        client.get_vhost_names.return_value = ['vhost1', 'vhost2']
 
         self.collector.collect()
-
-        client.get_queue.assert_called_once_with('test/queue', None)
+        
         client.get_queues.assert_not_called()
+        client.get_nodes.assert_called_once_with()
+        client.get_node.assert_called_once_with('rabbit@localhost')
+        client.get_vhost_names.assert_called_once_with()
+        client.get_queue.assert_has_calls([
+            call('vhost1', 'queue1'),
+            call('vhost1', 'queue2'),
+            call('vhost2', 'queue3'),
+            call('vhost2', 'queue4'),
+        ], any_order=True)
+        
+        metrics = {
+            'queues.queue1.key': 1,
+            'queues.queue2.key': 2,
+            'queues.queue3.key': 4,
+            'queues.queue4.key': 5,
+            'health.fd_used': 1,
+            'health.fd_total': 2,
+            'health.mem_used': 2,
+            'health.mem_limit': 4,
+            'health.sockets_used': 1,
+            'health.sockets_total': 2,
+            'health.disk_free_limit': 1,
+            'health.disk_free': 1,
+            'health.proc_used': 1,
+            'health.proc_total': 1,
+            'cluster.partitions': 0,
+            'cluster.nodes': 3
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
 
         self.collector.config['query_individual_queues'] = False
-        self.collector.config['queues'] = 'test/queue'
+        self.collector.config['queues'] = ''
+
+    @patch('rabbitmq.RabbitMQClient')
+    @patch.object(Collector, 'publish')
+    def test_opt_vhost_individual_queues(self, publish_mock, client_mock):
+        self.collector.config['query_individual_queues'] = True
+        self.collector.config['vhosts'] = {
+            'vhost1': 'queue1 queue2',
+            'vhost2': 'queue3 queue4'
+        }
+        client = Mock()
+        queue_data = {
+            'vhost1': {
+                'queue1': {
+                    'name': 'queue1',
+                    'key': 1,
+                    'string': 'str',
+                },
+                'queue2': {
+                    'name': 'queue2',
+                    'key': 2,
+                    'string': 'str',
+                },
+                'ignored': {
+                    'name': 'ignored',
+                    'key': 3,
+                    'string': 'str',
+                },
+            },
+            'vhost2': {
+                'queue3': {
+                    'name': 'queue3',
+                    'key': 4,
+                    'string': 'str',
+                },
+                'queue4': {
+                    'name': 'queue4',
+                    'key': 5,
+                    'string': 'str',
+                },
+                'ignored': {
+                    'name': 'ignored',
+                    'key': 6,
+                    'string': 'str',
+                }
+            }
+        }
+        overview_data = {
+            'node': 'rabbit@localhost',
+        }
+        node_health = {
+            'fd_used': 1,
+            'fd_total': 2,
+            'mem_used': 2,
+            'mem_limit': 4,
+            'sockets_used': 1,
+            'sockets_total': 2,
+            'disk_free_limit': 1,
+            'disk_free': 1,
+            'proc_used': 1,
+            'proc_total': 1,
+            'partitions': [],
+        }
+        client_mock.return_value = client
+        client.get_queue.side_effect = lambda v, q: queue_data.get(v).get(q)
+        client.get_overview.return_value = overview_data
+        client.get_nodes.return_value = [1, 2, 3]
+        client.get_node.return_value = node_health
+        client.get_vhost_names.return_value = ['vhost1', 'vhost2']
+
+        self.collector.collect()
+        
+        client.get_queues.assert_not_called()
+        client.get_nodes.assert_called_once_with()
+        client.get_node.assert_called_once_with('rabbit@localhost')
+        client.get_vhost_names.assert_called_once_with()
+        client.get_queue.assert_has_calls([
+            call('vhost1', 'queue1'),
+            call('vhost1', 'queue2'),
+            call('vhost2', 'queue3'),
+            call('vhost2', 'queue4'),
+        ], any_order=True)
+        
+        metrics = {
+            'vhosts.vhost1.queues.queue1.key': 1,
+            'vhosts.vhost1.queues.queue2.key': 2,
+            'vhosts.vhost2.queues.queue3.key': 4,
+            'vhosts.vhost2.queues.queue4.key': 5,
+            'health.fd_used': 1,
+            'health.fd_total': 2,
+            'health.mem_used': 2,
+            'health.mem_limit': 4,
+            'health.sockets_used': 1,
+            'health.sockets_total': 2,
+            'health.disk_free_limit': 1,
+            'health.disk_free': 1,
+            'health.proc_used': 1,
+            'health.proc_total': 1,
+            'cluster.partitions': 0,
+            'cluster.nodes': 3
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+        self.collector.config['query_individual_queues'] = False
+        del self.collector.config['vhosts']
 
 ##########################################################################
 if __name__ == "__main__":

--- a/src/collectors/rabbitmq/test/testrabbitmq.py
+++ b/src/collectors/rabbitmq/test/testrabbitmq.py
@@ -340,9 +340,6 @@ class TestRabbitMQCollector(CollectorTestCase):
             'cluster.nodes': 3
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
         self.collector.config['query_individual_queues'] = False
@@ -448,9 +445,6 @@ class TestRabbitMQCollector(CollectorTestCase):
             'cluster.nodes': 3
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
         self.collector.config['query_individual_queues'] = False


### PR DESCRIPTION
For vhosts with a large number of queues, fetching all of them at once can time out.
If queues are specified, this option will ensure that they are queried individually
