### PR TITLE
Removing dev/proc/sys mount restriction from DiskSpaceCollector

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -13,6 +13,7 @@ pymongo<3.0
 # https://github.com/BrightcoveOS/Diamond/issues/650
 #pyrabbit
 statsd
+Cython
 pyutmp
 redis
 simplejson

--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -144,11 +144,6 @@ class DiskSpaceCollector(diamond.collector.Collector):
                                    "exclude_filter list.", mount_point)
                     continue
 
-                if ((mount_point.startswith('/dev') or
-                     mount_point.startswith('/proc') or
-                     mount_point.startswith('/sys'))):
-                    continue
-
                 if ((('/' in device or device == 'tmpfs') and
                      mount_point.startswith('/'))):
                     try:

--- a/src/collectors/diskspace/test/fixtures/proc_mounts
+++ b/src/collectors/diskspace/test/fixtures/proc_mounts
@@ -12,3 +12,4 @@ none /var/run tmpfs rw,nosuid,relatime,mode=755 0 0
 none /var/lock tmpfs rw,nosuid,nodev,noexec,relatime 0 0
 /etc/auto.misc /misc autofs rw,relatime,fd=6,pgrp=1171,timeout=300,minproto=5,maxproto=5,indirect 0 0
 tmpfs /tmp tmpfs rw,relatime,size=524288k 0 0
+tmpfs /sys/fs/cgroup tmpfs rw 0 0

--- a/src/collectors/diskspace/test/testdiskspace.py
+++ b/src/collectors/diskspace/test/testdiskspace.py
@@ -42,6 +42,29 @@ class TestDiskSpaceCollector(CollectorTestCase):
     def test_import(self):
         self.assertTrue(DiskSpaceCollector)
 
+    def run_collection(self, statvfs_mock, os_major, os_minor):
+        os_stat_mock = patch('os.stat')
+        os_major_mock = patch('os.major', Mock(return_value=os_major))
+        os_minor_mock = patch('os.minor', Mock(return_value=os_minor))
+        os_path_isdir_mock = patch('os.path.isdir', Mock(return_value=False))
+        open_mock = patch('__builtin__.open',
+                          Mock(return_value=self.getFixture('proc_mounts')))
+        os_statvfs_mock = patch('os.statvfs', Mock(return_value=statvfs_mock))
+
+        os_stat_mock.start()
+        os_major_mock.start()
+        os_minor_mock.start()
+        os_path_isdir_mock.start()
+        open_mock.start()
+        os_statvfs_mock.start()
+        self.collector.collect()
+        os_stat_mock.stop()
+        os_major_mock.stop()
+        os_minor_mock.stop()
+        os_path_isdir_mock.stop()
+        open_mock.stop()
+        os_statvfs_mock.stop()
+
     @run_only_if_major_is_available
     @patch('os.access', Mock(return_value=True))
     def test_get_file_systems(self):
@@ -108,27 +131,7 @@ class TestDiskSpaceCollector(CollectorTestCase):
         statvfs_mock.f_flag = 4096
         statvfs_mock.f_namemax = 255
 
-        os_stat_mock = patch('os.stat')
-        os_major_mock = patch('os.major', Mock(return_value=9))
-        os_minor_mock = patch('os.minor', Mock(return_value=0))
-        os_path_isdir_mock = patch('os.path.isdir', Mock(return_value=False))
-        open_mock = patch('__builtin__.open',
-                          Mock(return_value=self.getFixture('proc_mounts')))
-        os_statvfs_mock = patch('os.statvfs', Mock(return_value=statvfs_mock))
-
-        os_stat_mock.start()
-        os_major_mock.start()
-        os_minor_mock.start()
-        os_path_isdir_mock.start()
-        open_mock.start()
-        os_statvfs_mock.start()
-        self.collector.collect()
-        os_stat_mock.stop()
-        os_major_mock.stop()
-        os_minor_mock.stop()
-        os_path_isdir_mock.stop()
-        open_mock.stop()
-        os_statvfs_mock.stop()
+        self.run_collection(statvfs_mock, 9, 0)
 
         metrics = {
             'root.gigabyte_used': (284.525, 2),
@@ -152,7 +155,8 @@ class TestDiskSpaceCollector(CollectorTestCase):
             'interval': 10,
             'byte_unit': ['gigabyte'],
             'exclude_filters': [],
-            'filesystems': 'tmpfs'
+            'filesystems': 'tmpfs',
+            'exclude_filters': '^/sys'
         })
 
         self.collector = DiskSpaceCollector(config, None)
@@ -168,27 +172,7 @@ class TestDiskSpaceCollector(CollectorTestCase):
         statvfs_mock.f_flag = 4096
         statvfs_mock.f_namemax = 255
 
-        os_stat_mock = patch('os.stat')
-        os_major_mock = patch('os.major', Mock(return_value=4))
-        os_minor_mock = patch('os.minor', Mock(return_value=0))
-        os_path_isdir_mock = patch('os.path.isdir', Mock(return_value=False))
-        open_mock = patch('__builtin__.open',
-                          Mock(return_value=self.getFixture('proc_mounts')))
-        os_statvfs_mock = patch('os.statvfs', Mock(return_value=statvfs_mock))
-
-        os_stat_mock.start()
-        os_major_mock.start()
-        os_minor_mock.start()
-        os_path_isdir_mock.start()
-        open_mock.start()
-        os_statvfs_mock.start()
-        self.collector.collect()
-        os_stat_mock.stop()
-        os_major_mock.stop()
-        os_minor_mock.stop()
-        os_path_isdir_mock.stop()
-        open_mock.stop()
-        os_statvfs_mock.stop()
+        self.run_collection(statvfs_mock, 4, 0)
 
         metrics = {
             'tmp.gigabyte_used': (284.525, 2),
@@ -197,6 +181,47 @@ class TestDiskSpaceCollector(CollectorTestCase):
             'tmp.inodes_used': 348873,
             'tmp.inodes_free': 91229495,
             'tmp.inodes_avail': 91229495,
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @run_only_if_major_is_available
+    @patch('os.access', Mock(return_value=True))
+    @patch.object(Collector, 'publish')
+    def test_should_work_in_system_directories(self, publish_mock):
+        config = get_collector_config('DiskSpaceCollector', {
+            'interval': 10,
+            'byte_unit': ['gigabyte'],
+            'exclude_filters': [],
+            'filesystems': 'tmpfs',
+            'exclude_filters': '^/tmp'
+        })
+
+        self.collector = DiskSpaceCollector(config, None)
+        statvfs_mock = Mock()
+        statvfs_mock.f_bsize = 4096
+        statvfs_mock.f_frsize = 4096
+        statvfs_mock.f_blocks = 360540255
+        statvfs_mock.f_bfree = 285953527
+        statvfs_mock.f_bavail = 267639130
+        statvfs_mock.f_files = 91578368
+        statvfs_mock.f_ffree = 91229495
+        statvfs_mock.f_favail = 91229495
+        statvfs_mock.f_flag = 4096
+        statvfs_mock.f_namemax = 255
+
+        self.run_collection(statvfs_mock, 4, 0)
+
+        metrics = {
+            '_sys_fs_cgroup.gigabyte_used': (284.525, 2),
+            '_sys_fs_cgroup.gigabyte_free': (1090.826, 2),
+            '_sys_fs_cgroup.gigabyte_avail': (1020.962, 2),
+            '_sys_fs_cgroup.inodes_used': 348873,
+            '_sys_fs_cgroup.inodes_free': 91229495,
+            '_sys_fs_cgroup.inodes_avail': 91229495,
         }
 
         self.setDocExample(collector=self.collector.__class__.__name__,


### PR DESCRIPTION
We're trying to collect data about a tmpfs mount at `/dev` and under `/sys` and diskspace.py will skip right over those mount points. There's no comment as to why this is done, unlike the previous checks, and given [issue#262](https://github.com/python-diamond/Diamond/issues/262) I wouldn't be surprised if the original purpose has been lost. We aren't seeing any issue when we manually do the heavy lifting:

```
>>> def test(string):
...     stat = os.stat(string)
...     major = os.major(stat.st_dev)
...     minor = os.minor(stat.st_dev)
...     print stat
...     print major
...     print minor
...
>>> test('/dev')
posix.stat_result(st_mode=16877, st_ino=1025, st_dev=5L, st_nlink=14, st_uid=0, st_gid=0, st_size=4280, st_atime=1456860792, st_mtime=1460050361, st_ctime=1460050361)
0
5
>>> test('/run')
posix.stat_result(st_mode=16877, st_ino=1212, st_dev=16L, st_nlink=20, st_uid=0, st_gid=0, st_size=700, st_atime=1456868938, st_mtime=1460151861, st_ctime=1460151861)
0
16
```

This check should be removed if it doesn't have a purpose. If it does then there should at least be a comment or abstraction to explain why this restriction is in place.

To give some context, these are our tmpfs mount locations that would be great to monitor:

```
$ sudo cat /proc/mounts | grep tmpfs
udev /dev devtmpfs rw,relatime,size=24650316k,nr_inodes=6162579,mode=755 0 0
tmpfs /run tmpfs rw,nosuid,noexec,relatime,size=4932236k,mode=755 0 0
none /sys/fs/cgroup tmpfs rw,relatime,size=4k,mode=755 0 0
none /run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k 0 0
none /run/shm tmpfs rw,nosuid,nodev,relatime 0 0
none /run/user tmpfs rw,nosuid,nodev,noexec,relatime,size=102400k,mode=755 0 0
```
