### PR TITLE
Add ntp collector

### DIFF
--- a/docs/collectors/NtpCollector.md
+++ b/docs/collectors/NtpCollector.md
@@ -1,0 +1,49 @@
+<!--This file was generated from the python source
+Please edit the source to make changes
+-->
+NtpCollector
+=====
+
+Collect out of band stats from ntp
+
+Uses output from ntpdate:
+
+```
+$ ntpdate -q pool.ntp.org
+server 12.34.56.1, stratum 2, offset -0.000277, delay 0.02878
+server 12.34.56.2, stratum 1, offset -0.000128, delay 0.02896
+server 12.34.56.3, stratum 2, offset 0.000613, delay 0.02870
+server 12.34.56.4, stratum 2, offset -0.000351, delay 0.02864
+31 Apr 12:00:00 ntpdate[12]: adjust time server 12.34.56.2 offset -0.000128 sec
+$
+```
+
+#### Dependencies
+
+    * /usr/sbin/ntpdate
+    * subprocess
+
+
+#### Options
+
+Setting | Default | Description | Type
+--------|---------|-------------|-----
+bin | /usr/sbin/ntpdate | Path to ntpdate binary | str
+byte_unit | byte | Default numeric output(s) | str
+enabled | False | Enable collecting these metrics | bool
+measure_collector_time | False | Collect the collector run time in ms | bool
+metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
+metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
+ntp_pool | pool.ntp.org | NTP Pool address | str
+precision | 0 | Number of decimal places to report to | int
+sudo_cmd | /usr/bin/sudo | Path to sudo | str
+time_scale | milliseconds | Time unit to report offset in | str
+use_sudo | False | Use sudo? | bool
+
+#### Example Output
+
+```
+servers.hostname.ntp.offset.milliseconds 0
+servers.hostname.ntp.server.count 4
+```
+

--- a/src/collectors/ntp/ntp.py
+++ b/src/collectors/ntp/ntp.py
@@ -1,0 +1,99 @@
+# coding=utf-8
+
+"""
+Collect out of band stats from ntp
+
+Uses output from ntpdate:
+
+```
+$ ntpdate -q pool.ntp.org
+server 12.34.56.1, stratum 2, offset -0.000277, delay 0.02878
+server 12.34.56.2, stratum 1, offset -0.000128, delay 0.02896
+server 12.34.56.3, stratum 2, offset 0.000613, delay 0.02870
+server 12.34.56.4, stratum 2, offset -0.000351, delay 0.02864
+31 Apr 12:00:00 ntpdate[12]: adjust time server 12.34.56.2 offset -0.000128 sec
+$
+```
+
+#### Dependencies
+
+    * /usr/sbin/ntpdate
+    * subprocess
+
+"""
+
+import subprocess
+
+import diamond.collector
+from diamond.collector import str_to_bool
+from diamond import convertor
+
+
+class NtpCollector(diamond.collector.ProcessCollector):
+
+    def get_default_config_help(self):
+        config_help = super(NtpCollector, self).get_default_config_help()
+        config_help.update({
+            'bin':      'Path to ntpdate binary',
+            'ntp_pool': 'NTP Pool address',
+            'precision': 'Number of decimal places to report to',
+            'time_scale': 'Time unit to report offset in',
+        })
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings
+        """
+        config = super(NtpCollector, self).get_default_config()
+        config.update({
+            'bin':      self.find_binary('/usr/sbin/ntpdate'),
+            'ntp_pool': 'pool.ntp.org',
+            'path':     'ntp',
+            'precision': 0,
+            'time_scale': 'milliseconds',
+        })
+        return config
+
+    def get_ntpdate_stats(self):
+        output = self.run_command(['-q', self.config['ntp_pool']])
+
+        data = {}
+        data['server.count'] = {'val': 0, 'precision': 0}
+
+        for line in output[0].splitlines():
+            # Only care about best choice not all servers
+            if line.startswith('server'):
+                data['server.count']['val'] += 1
+                continue
+
+            parts = line.split()
+
+            # Make sure we have the correct output
+            # Sample of line: 31 Apr 12:00:00 ntpdate[12345]: adjust time \
+            #   server 123.456.789.2 offset -0.000123 sec
+            if len(parts) != 11:
+                self.log.error('NtpCollector: Output of ntpdate was %s words '
+                               'long but was expected to be 11' % len(parts))
+                self.log.debug('NtpCollector: ntpdate output was %s' % parts)
+                continue
+
+            # offset is in seconds, convert is to nanoseconds and miliseconds
+            offset_in_s = float(parts[9])
+
+            # Convert to the requested time unit
+            offset = convertor.time.convert(offset_in_s,
+                                            's',
+                                            self.config['time_scale'])
+
+            # Determine metric namespace based on given time unit
+            metric_name = 'offset.%s' % self.config['time_scale']
+
+            data[metric_name] = {'val': offset,
+                                 'precision': self.config['precision']}
+
+        return data.items()
+
+    def collect(self):
+        for stat, v in self.get_ntpdate_stats():
+            self.publish(stat, v['val'], precision=v['precision'])

--- a/src/collectors/ntp/test/fixtures/ntpdate
+++ b/src/collectors/ntp/test/fixtures/ntpdate
@@ -1,0 +1,5 @@
+server 12.34.56.1, stratum 2, offset -0.000277, delay 0.02878
+server 12.34.56.2, stratum 1, offset -0.000128, delay 0.02896
+server 12.34.56.3, stratum 2, offset 0.000613, delay 0.02870
+server 12.34.56.4, stratum 2, offset -0.000351, delay 0.02864
+31 Apr 12:00:00 ntpdate[12]: adjust time server 12.34.56.2 offset -0.000128 sec

--- a/src/collectors/ntp/test/testntp.py
+++ b/src/collectors/ntp/test/testntp.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+# coding=utf-8
+##########################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import patch
+
+from diamond.collector import Collector
+
+from ntp import NtpCollector
+
+##########################################################################
+
+
+class TestNtpCollector(CollectorTestCase):
+
+    def setUp(self):
+        config = get_collector_config('NtpCollector', {})
+
+        self.collector = NtpCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(NtpCollector)
+
+    @patch.object(Collector, 'publish')
+    def test_should_work_wtih_real_data(self, publish_mock):
+        ntpdate_data = Mock(
+            return_value=(self.getFixture('ntpdate').getvalue(), None))
+        collector_mock = patch.object(NtpCollector,
+                                      'run_command',
+                                      ntpdate_data)
+        collector_mock.start()
+        self.collector.collect()
+        collector_mock.stop()
+
+        metrics = {
+            'server.count': 4,
+            'offset.milliseconds': 0
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_should_work_wtih_real_data_and_custom_config(self, publish_mock):
+        config = get_collector_config('NtpCollector', {
+            'time_scale': 'seconds',
+            'precision': 3,
+        })
+
+        self.collector = NtpCollector(config, None)
+
+        ntpdate_data = Mock(
+            return_value=(self.getFixture('ntpdate').getvalue(), None))
+        collector_mock = patch.object(NtpCollector,
+                                      'run_command',
+                                      ntpdate_data)
+        collector_mock.start()
+        self.collector.collect()
+        collector_mock.stop()
+
+        metrics = {
+            'server.count': 4,
+            'offset.seconds': -0.000128
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_should_fail_gracefully(self, publish_mock):
+        ntpdate_data = Mock(return_value=('', None))
+        collector_mock = patch.object(NtpCollector,
+                                      'run_command',
+                                      ntpdate_data)
+
+        collector_mock.start()
+        self.collector.collect()
+        collector_mock.stop()
+
+        self.assertPublishedMany(publish_mock, {})
+
+##########################################################################
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Collect out of band stats from ntp

Uses output from ntpdate:

```
$ ntpdate -q pool.ntp.org
server 12.34.56.1, stratum 2, offset -0.000277, delay 0.02878
server 12.34.56.2, stratum 1, offset -0.000128, delay 0.02896
server 12.34.56.3, stratum 2, offset 0.000613, delay 0.02870
server 12.34.56.4, stratum 2, offset -0.000351, delay 0.02864
31 Apr 12:00:00 ntpdate[12]: adjust time server 12.34.56.2 offset -0.000128 sec
$