### PR TITLE
rpm : remove --log-stdout in systemd script

### DIFF
--- a/rpm/systemd/diamond.service
+++ b/rpm/systemd/diamond.service
@@ -2,7 +2,7 @@
 Description=diamond - A system statistics collector for graphite
 
 [Service]
-ExecStart=/usr/bin/python /usr/bin/diamond --log-stdout --foreground
+ExecStart=/usr/bin/python /usr/bin/diamond --foreground
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
On systemd setup, with this flag enabled, log is always going to stdout (journald) whatever configuration supplied.

Both behavior are configureable (diamond.conf) without the flag.

This PR may be another way to solve #406 
