### PR TITLE
remove README.md from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include         LICENSE
-include         README.md
 include         MANIFEST.in
 include         version.txt
 include         .keep


### PR DESCRIPTION
This PR fixes a bug that was introduced after README.md was changed to a symlink.
Basically bdists were failing with this:

```
# /usr/bin/python setup.py --command-packages=stdeb.command sdist_dsc --guess-conflicts-provides-replaces=True bdist_deb
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
running sdist_dsc
error: [Errno 2] No such file or directory: 'README.md'
```

This patch prevents README.md from being included in the source distribution and uploaded.