### PR TITLE
Fix in setup.py for oracle linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ else:
         if distro == 'Ubuntu':
             data_files.append(('/etc/init',
                                ['debian/diamond.upstart']))
-        if distro in ['centos', 'redhat', 'debian', 'fedora']:
+        if distro in ['centos', 'redhat', 'debian', 'fedora', 'oracle']:
             data_files.append(('/etc/init.d',
                                ['bin/init.d/diamond']))
             data_files.append(('/var/log/diamond',


### PR DESCRIPTION
I decided to test @thematt's proposed fix for #441 so I ran oracle linux in a container to verify everything works as expected:

```bash
docker pull oraclelinux
docker run -it oraclelinux
```

From inside the container I set up:

```
yum install -y git python-configobj
cd /opt/
git clone https://github.com/python-diamond/Diamond.git
cd Diamond
python setup.py install
``` 

And verified installation (before and after fix) by checking for the following files:

```bash
ls /etc/init.d/diamond
ls /var/log/diamond/.keep
ls /usr/lib/systemd/system/diamond.service
```