### PR TITLE
Added unit awareness to client io output for CephStatsCollector

### DIFF
--- a/src/collectors/cephstats/cephstats.py
+++ b/src/collectors/cephstats/cephstats.py
@@ -47,14 +47,14 @@ def process_ceph_status(output):
         if runit is None:
             self.log.exception('Could not get read units')
             return {}
-        ret['rd'] = to_bytes(rd.group(), runit.group())
+        ret['rd'] = repr(to_bytes(rd.group(), runit.group()))
         wr = numberchk.search(ceph_stats, rd.end())
         if wr is not None:
             wunit = unitchk.search(ceph_stats, wr.end())
             if runit is None:
                 self.log.exception('Could not get read units')
                 return {}
-            ret['wr'] = to_bytes(wr.group(), wunit.group())
+            ret['wr'] = repr(to_bytes(wr.group(), wunit.group()))
             iops = numberchk.search(ceph_stats, wr.end())
             if iops is not None:
                 ret['iops'] = iops.group()

--- a/src/collectors/cephstats/cephstats.py
+++ b/src/collectors/cephstats/cephstats.py
@@ -14,10 +14,19 @@ from ceph import CephCollector
 
 patternchk = re.compile(r'\bclient io .*')
 numberchk = re.compile(r'\d+')
-
+unitchk = re.compile(r'[a-zA-Z]{1,2}')
 
 # This is external to the CephCollector so it can be tested
 # separately.
+def to_bytes(value, unit):
+    fval = float(value)
+    unit = str(unit.lower()).strip()
+    if unit == "b":
+        return fval
+    unit_list = {'kb' : 1, 'mb': 2, 'gb' : 3, 'tb' : 4, 'pb' : 5, 'eb' : 6 }
+    for i in range(unit_list[unit]):
+        fval = fval * 1000
+    return fval
 def process_ceph_status(output):
     res = patternchk.search(output)
     if not res:
@@ -26,13 +35,21 @@ def process_ceph_status(output):
     if not ceph_stats:
         return {}
     ret = {}
-    rd = wr = iops = None
+    rd = wr = iops = runit = wunit = None
     rd = numberchk.search(ceph_stats)
     if rd is not None:
-        ret['rd'] = rd.group()
+        runit = unitchk.search(ceph_stats, rd.end())
+        if runit is None:
+            self.log.exception('Could not get read units')
+            return {}
+        ret['rd'] = to_bytes(rd.group(), runit.group())
         wr = numberchk.search(ceph_stats, rd.end())
         if wr is not None:
-            ret['wr'] = wr.group()
+            wunit = unitchk.search(ceph_stats, wr.end())
+            if runit is None:
+                self.log.exception('Could not get read units')
+                return {}
+            ret['wr'] = to_bytes(wr.group(), wunit.group())
             iops = numberchk.search(ceph_stats, wr.end())
             if iops is not None:
                 ret['iops'] = iops.group()
@@ -40,7 +57,6 @@ def process_ceph_status(output):
 
 
 class CephStatsCollector(CephCollector):
-
     def _get_stats(self):
         """
         Get ceph stats
@@ -52,7 +68,6 @@ class CephStatsCollector(CephCollector):
                 'Could not get stats: %s' % err)
             self.log.exception('Could not get stats')
             return {}
-
         return process_ceph_status(output)
 
     def collect(self):
@@ -61,5 +76,4 @@ class CephStatsCollector(CephCollector):
         """
         stats = self._get_stats()
         self._publish_stats('cephstats', stats)
-
         return

--- a/src/collectors/cephstats/cephstats.py
+++ b/src/collectors/cephstats/cephstats.py
@@ -8,9 +8,10 @@ import subprocess
 import re
 import os
 import sys
+from ceph import CephCollector
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)),
                                 'ceph'))
-from ceph import CephCollector
+
 
 patternchk = re.compile(r'\bclient io .*')
 numberchk = re.compile(r'\d+')
@@ -18,15 +19,19 @@ unitchk = re.compile(r'[a-zA-Z]{1,2}')
 
 # This is external to the CephCollector so it can be tested
 # separately.
+
+
 def to_bytes(value, unit):
     fval = float(value)
     unit = str(unit.lower()).strip()
     if unit == "b":
         return fval
-    unit_list = {'kb' : 1, 'mb': 2, 'gb' : 3, 'tb' : 4, 'pb' : 5, 'eb' : 6 }
+    unit_list = {'kb': 1, 'mb': 2, 'gb': 3, 'tb': 4, 'pb': 5, 'eb': 6}
     for i in range(unit_list[unit]):
         fval = fval * 1000
     return fval
+
+
 def process_ceph_status(output):
     res = patternchk.search(output)
     if not res:

--- a/src/collectors/cephstats/test/test_ceph.py
+++ b/src/collectors/cephstats/test/test_ceph.py
@@ -22,7 +22,7 @@ class TestCephStats(unittest.TestCase):
         Get ceph information from sample data
         """
         f = open('sample.txt')
-        ret = {'rd': '8643', 'wr': '4821', 'iops': '481'}
+        ret = {'rd': '8643000.0', 'wr': '4821000.0', 'iops': '481'}
         self.assertEqual(process_ceph_status(f.read()), ret)
         f.close()
 


### PR DESCRIPTION
The ceph -s command scales io rates, but the code was just collecting the raw digits.
Code now converts rates in the KB to EB range to bytes.

Specifically, the code in master currently sees a client io read or write rate of 1234 kB/s and stores that as 1234. It also stores 1234 if the rate is 1234 B/s or 1234 MB/s, etc. Now it stores 1234.0 if the unit is B/s, 1234000.0 if the unit is kB/s, 1234000000 if the unit is MB/s, etc.
