### PR TITLE
Add Basic/Shield auth to elasticsearch collector

### DIFF
--- a/docs/collectors/ElasticSearchCollector.md
+++ b/docs/collectors/ElasticSearchCollector.md
@@ -27,12 +27,14 @@ logstash_mode | False | If 'indices' stats are gathered, remove the YYYY.MM.DD s
 measure_collector_time | False | Collect the collector run time in ms | bool
 metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
 metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
+password |  | Password for Basic/Shield auth | str
 port | 9200 |  | int
 stats | jvm, thread_pool, indices, | Available stats:<br>
  - jvm (JVM information)<br>
  - thread_pool (Thread pool information)<br>
  - indices (Individual index stats)<br>
  | list
+user |  | Username for Basic/Shield auth | str
 
 #### Example Output
 

--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -109,7 +109,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
         url = 'http://%s:%i/%s' % (host, port, path)
         try:
             request = urllib2.Request(url)
-	    if self.config['user'] and self.config['password']:
+            if self.config['user'] and self.config['password']:
                 base64string = base64.standard_b64encode(
                     '%s:%s' % (self.config['user'], self.config['password']))
                 request.add_header("Authorization", "Basic %s" % base64string)

--- a/src/collectors/elasticsearch/test/testelasticsearch.py
+++ b/src/collectors/elasticsearch/test/testelasticsearch.py
@@ -51,6 +51,12 @@ class TestElasticSearchCollector(CollectorTestCase):
         })
 
     @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data_and_basic_auth(self, publish_mock):
+            self.collector.config["user"] = "user"
+            self.collector.config["password"] = "password"
+            self.test_should_work_with_real_data()
+
+    @patch.object(Collector, 'publish')
     def test_should_work_with_real_data(self, publish_mock):
         returns = [
             self.getFixture('stats'),


### PR DESCRIPTION
Current implementation of Elasticsearch collector has no ability to authenticate against Shield plugin for Elasticsearch, so I've added optional parameters to authenticate with.
I'm using this version of collector in prod right now and it works just fine.
