### PR TITLE
Force xenfix as opt-in

### DIFF
--- a/src/collectors/cpu/cpu.py
+++ b/src/collectors/cpu/cpu.py
@@ -55,7 +55,7 @@ class CPUCollector(diamond.collector.Collector):
         config.update({
             'path':     'cpu',
             'percore':  'True',
-            'xenfix':   None,
+            'xenfix':   'False',
             'simple':   'False',
             'normalize': 'False',
         })
@@ -167,7 +167,9 @@ class CPUCollector(diamond.collector.Collector):
 
             # Check for a bug in xen where the idle time is doubled for guest
             # See https://bugzilla.redhat.com/show_bug.cgi?id=624756
-            if self.config['xenfix'] is None or self.config['xenfix'] is True:
+            # Fixed http://rhn.redhat.com/errata/RHSA-2012-0862.html
+            # Keeping for possibility of users running old Xen systems.
+            if self.config['xenfix'] is True:
                 if os.path.isdir('/proc/xen'):
                     total = 0
                     for metric_name in metrics.keys():

--- a/src/collectors/cpu/test/testcpu.py
+++ b/src/collectors/cpu/test/testcpu.py
@@ -107,7 +107,7 @@ class TestCPUCollector(CollectorTestCase):
         patch_open.stop()
 
         metrics = {
-            'total.idle': 68.4,
+            'total.idle': 136.8,
             'total.iowait': 0.6,
             'total.nice': 0.0,
             'total.system': 13.7,


### PR DESCRIPTION
The bug in Xen which this fix was accommodating was fixed in 2012.
Currently all AWS machines use Xen hypervisors which are already fixed,
however because of the aggressive behavior of the "xenfix" in this collector, any machines that
are running Diamond on AWS hosts which have not actively configured this
setting are reporting incorrect CPU idle values. This is unfortunate as
this value is often used for provisioning cluster sizes and the like.

Optionally it's likely safe to remove the code altogether, as anyone running an old Xen hypervisor likely isn't keeping their Diamond core up-to-date. But who knows the unique use-cases of certain situations.

EDIT: 
The original bug report: https://bugzilla.redhat.com/show_bug.cgi?id=624756
The fix (2012): http://rhn.redhat.com/errata/RHSA-2012-0862.html