### PR TITLE
add option to libvirtkvm collector to build instance name based on openstack metadata

### DIFF
--- a/docs/collectors/LibvirtKVMCollector.md
+++ b/docs/collectors/LibvirtKVMCollector.md
@@ -28,10 +28,10 @@ specific to the compute node | bool
 uri | qemu:///system | The libvirt connection URI. By default it's<br>
 'qemu:///system'. One decent option is<br>
 'qemu+unix:///system?socket=/var/run/libvirt/libvit-sock-ro'. | str
+format_name_using_metadata | False | Use openstack metadata to generate instance name, its useful when do you and to group VMs metrics by project | string, possible options: ${owner_project},${owner_project_uuid},${instance},${instance_uuid}
 
 #### Example Output
 
 ```
 __EXAMPLESHERE__
 ```
-


### PR DESCRIPTION
add option to libvirtkvm collector to build instance name based on openstack metadata, this is useful to group VMs tenant metrics on Openstack.