### PR TITLE
Collect diskusage statistics for FusionIO Cards.

### DIFF
--- a/src/collectors/diskusage/diskusage.py
+++ b/src/collectors/diskusage/diskusage.py
@@ -63,7 +63,8 @@ class DiskUsageCollector(diamond.collector.Collector):
                          '|sd[a-z]+[0-9]*$' +
                          '|x?vd[a-z]+[0-9]*$' +
                          '|disk[0-9]+$' +
-                         '|dm\-[0-9]+$'),
+                         '|dm\-[0-9]+$' +
+                         '|fio[a-z]+$'),
             'sector_size': 512,
             'send_zero': False,
         })


### PR DESCRIPTION
We're using FusionIO Cards for things and the diskusage collector doesn't collect that data due to the regex in use.  This patch adds that functionality.
