### PR TITLE
graphite handler: add parameter to control interval reconnecting

### DIFF
--- a/docs/handlers/GraphiteHandler.md
+++ b/docs/handlers/GraphiteHandler.md
@@ -34,3 +34,4 @@ scope_id | 0 | IPv6 Scope ID | int
 server_error_interval | 120 | How frequently to send repeated server errors | int
 timeout | 15 |  | int
 trim_backlog_multiplier | 4 | Trim down how many batches | int
+reconnect_interval | 0 | How often (in seconds) to reconnect to graphite. Default (0) is never | int


### PR DESCRIPTION
Default behaviour (neverending connections) is unchanged.

Setting this parameter allows you to re-balance the load on a loadbalanced cluster after node maintenance or an incident.  Without this feature you would have all Diamond instances unevenly connected to the Graphite nodes, until you restart all Diamond instances.