### PR TITLE
Update InfluxDBHandler for newest InfluxDB library

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -19,3 +19,4 @@ simplejson
 setproctitle
 psycopg2
 PySensors
+influxdb

--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -212,7 +212,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
                     self.log.exception(e)
                     continue
 
-                block_size = data.f_bsize
+                block_size = data.f_frsize
 
                 blocks_total = data.f_blocks
                 blocks_free = data.f_bfree

--- a/src/diamond/handler/test/testinfluxdbhandler.py
+++ b/src/diamond/handler/test/testinfluxdbhandler.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+# coding=utf-8
+##########################################################################
+
+import configobj
+
+from test import unittest, run_only
+
+from mock import Mock, patch
+
+from diamond.handler.influxdbHandler import InfluxdbHandler
+from diamond.metric import Metric
+
+
+def run_only_if_influxdb_is_available(func):
+    try:
+        import influxdb
+    except ImportError:
+        influxdb = None
+    pred = lambda: influxdb is not None
+    return run_only(func, pred)
+
+
+class TestInfluxdbHandler(unittest.TestCase):
+    @run_only_if_influxdb_is_available
+    def test_single_metric_process_v_0_9(self):
+        config = configobj.ConfigObj()
+        config['batch_size'] = 1
+
+        metric = Metric('servers.com.example.www.cpu.total.idle',
+                        0, timestamp=1234567, host='will-be-ignored')
+
+        handler = InfluxdbHandler(config)
+        handler.time_multiplier = float('-inf')
+
+        request_mock = Mock()
+        patch_request = patch.object(handler.influx, 'request', request_mock)
+        patch_request.start()
+        handler.process(metric)
+        patch_request.stop()
+
+        expected_result = \
+            'servers.com.example.www.cpu.total.idle value=0i 1234567\n'
+
+        self.assertEqual(request_mock.call_count, 1)
+        self.assertEqual(request_mock.call_args[1]['data'], expected_result)
+
+    @run_only_if_influxdb_is_available
+    def test_multiple_metric_process_v_0_9(self):
+        config = configobj.ConfigObj()
+        num = 3
+        config['batch_size'] = num
+
+        handler = InfluxdbHandler(config)
+        handler.time_multiplier = float('-inf')
+
+        request_mock = Mock()
+        patch_request = patch.object(handler.influx, 'request', request_mock)
+        patch_request.start()
+        for i in range(num):
+            metric = Metric('servers.com.example.www.cpu.total.idle',
+                            i, timestamp=1234567 + i, host='will-be-ignored')
+            handler.process(metric)
+        patch_request.stop()
+
+        expected_result = \
+            'servers.com.example.www.cpu.total.idle value=0i 1234567\n' + \
+            'servers.com.example.www.cpu.total.idle value=1i 1234568\n' + \
+            'servers.com.example.www.cpu.total.idle value=2i 1234569\n'
+
+        self.assertEqual(request_mock.call_count, 1)
+        self.assertEqual(request_mock.call_args[1]['data'], expected_result)
+
+    @run_only_if_influxdb_is_available
+    def test_single_metric_process_v_0_8(self):
+        config = configobj.ConfigObj()
+        config['influxdb_version'] = '0.8'
+        config['batch_size'] = 1
+
+        metric = Metric('servers.com.example.www.cpu.total.idle',
+                        0, timestamp=1234567, host='will-be-ignored')
+
+        handler = InfluxdbHandler(config)
+        handler.time_multiplier = float('-inf')
+
+        request_mock = Mock()
+        patch_request = patch.object(handler.influx, 'request', request_mock)
+        patch_request.start()
+        handler.process(metric)
+        patch_request.stop()
+
+        expected_result = [dict(columns=['time', 'value'],
+                                name='servers.com.example.www.cpu.total.idle',
+                                points=[[1234567, 0]])]
+
+        self.assertEqual(request_mock.call_count, 1)
+        self.assertEqual(request_mock.call_args[1]['data'], expected_result)
+
+    @run_only_if_influxdb_is_available
+    def test_multiple_metric_process_v_0_8(self):
+        config = configobj.ConfigObj()
+        config['influxdb_version'] = '0.8'
+        num = 3
+        config['batch_size'] = num
+
+        handler = InfluxdbHandler(config)
+        handler.time_multiplier = float('-inf')
+
+        request_mock = Mock()
+        patch_request = patch.object(handler.influx, 'request', request_mock)
+        patch_request.start()
+        for i in range(num):
+            metric = Metric('servers.com.example.www.cpu.total.idle',
+                            i, timestamp=1234567 + i, host='will-be-ignored')
+            handler.process(metric)
+        patch_request.stop()
+
+        expected_result = [dict(columns=['time', 'value'],
+                                name='servers.com.example.www.cpu.total.idle',
+                                points=[[1234567, 0], [1234568, 1],
+                                        [1234569, 2]])]
+
+        self.assertEqual(request_mock.call_count, 1)
+        self.assertEqual(request_mock.call_args[1]['data'], expected_result)


### PR DESCRIPTION
This is a fix for ticket #297 and updates the InfluxDBHandler to work with the latest InfluxDB python library. There was a previous pull request at https://github.com/python-diamond/Diamond/pull/312 but there hasn't been any progress in the last few months so I decided to push my own taking care of the notes that @jaingaurav made.  The commit itself is a bit of an amalgamation between that pull request and [this branch](https://github.com/Clever/Diamond/blob/726e8cc8b4cf8d6de77d463155cab87bf1f4ffee/src/diamond/handler/influxdbHandler.py).