### PR TITLE
TCP collector: allow choosing metrics to be sent as gauges

### DIFF
--- a/src/collectors/tcp/tcp.py
+++ b/src/collectors/tcp/tcp.py
@@ -187,20 +187,19 @@ class TCPCollector(diamond.collector.Collector):
         '/proc/net/snmp'
     ]
 
-    GAUGES = [
-        'CurrEstab',
-        'MaxConn',
-    ]
-
     def process_config(self):
         super(TCPCollector, self).process_config()
         if self.config['allowed_names'] is None:
             self.config['allowed_names'] = []
 
+        if self.config['gauges'] is None:
+            self.config['gauges'] = ['CurrEstab', 'MaxConn']
+
     def get_default_config_help(self):
         config_help = super(TCPCollector, self).get_default_config_help()
         config_help.update({
             'allowed_names': 'list of entries to collect, empty to collect all',
+            'gauges': 'list of metrics to be published as gauges',
         })
         return config_help
 
@@ -217,6 +216,7 @@ class TCPCollector(diamond.collector.Collector):
                 'TCPForwardRetrans, TCPSlowStartRetrans, CurrEstab, ' +
                 'TCPAbortOnMemory, TCPBacklogDrop, AttemptFails, ' +
                 'EstabResets, InErrs, ActiveOpens, PassiveOpens',
+            'gauges': 'CurrEstab, MaxConn',
         })
         return config
 
@@ -271,7 +271,7 @@ class TCPCollector(diamond.collector.Collector):
             value = long(metrics[metric_name])
 
             # Publish the metric
-            if metric_name in self.GAUGES:
+            if metric_name in self.config['gauges']:
                 self.publish_gauge(metric_name, value, 0)
             else:
                 self.publish_counter(metric_name, value, 0)

--- a/src/collectors/tcp/test/testtcp.py
+++ b/src/collectors/tcp/test/testtcp.py
@@ -20,11 +20,12 @@ from tcp import TCPCollector
 
 class TestTCPCollector(CollectorTestCase):
 
-    def setUp(self, allowed_names=None):
+    def setUp(self, allowed_names=None, gauges=None):
         if not allowed_names:
             allowed_names = []
         config = get_collector_config('TCPCollector', {
             'allowed_names': allowed_names,
+            'gauges': gauges,
             'interval': 1
         })
         self.collector = TCPCollector(config, None)


### PR DESCRIPTION
Add a new configuration option called 'gauges' allowing to specify which
metrics should be published as gauges.

The metrics published as gauges before this patch, 'CurrEstab' and
'MaxConn', have been chosen as the default value for the new
configuration option.