### PR TITLE
Allow precision to be set in nginx collector

### DIFF
--- a/docs/collectors/NginxCollector.md
+++ b/docs/collectors/NginxCollector.md
@@ -38,6 +38,7 @@ enabled | False | Enable collecting these metrics | bool
 measure_collector_time | False | Collect the collector run time in ms | bool
 metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
 metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
+precision | 0 | Number of decimal places to report to | int
 req_host | localhost | Hostname | str
 req_host_header | None | HTTP Host header (required for SSL) | NoneType
 req_path | /nginx_status | Path | str


### PR DESCRIPTION
This patch allows us to set precision in the Nginx collector's config file. Eg:

```
enabled = True
precision = 2
req_port = 9080
```

Changing the precision from 0 to 2 resulted in this change on a testing system when viewing the data in Grafana:

![asdf](http://i.imgur.com/Cf39tD7.png)

Note that the number of requests/sec hasn't changed, just the precision config value.

When you hover over a datapoint in Grafana:
- Some point in time before the patch:
  
  ![asdf](http://i.imgur.com/1QbmvJk.png)
- After the patch and changing the config value (with requests coming in at the same rate):
  
  ![asdf](http://i.imgur.com/bZqXN6j.png)
