### PR TITLE
Valuable stats are missed due to missing types

### DIFF
--- a/src/collectors/kafkastat/kafkastat.py
+++ b/src/collectors/kafkastat/kafkastat.py
@@ -131,14 +131,21 @@ class KafkaCollector(diamond.collector.Collector):
 
         for attrib in attributes.getiterator(tag='Attribute'):
             atype = attrib.get('type')
+            aval = attrib.get('value')
+            aname = attrib.get('name')
 
             ptype = self.ATTRIBUTE_TYPES.get(atype)
             if not ptype:
-                continue
+                if type(aval).__name__ == float:
+                    ptype = float
+                if type(aval).__name__ == int:
+                    ptype = int
+                else
+                    continue
 
-            value = ptype(attrib.get('value'))
+            value = ptype(aval)
 
-            name = '.'.join([key_prefix, attrib.get('name')])
+            name = '.'.join([key_prefix, aname])
             # Some prefixes and attributes could have spaces, thus we must
             # sanitize them
             name = name.replace(' ', '')

--- a/src/collectors/kafkastat/kafkastat.py
+++ b/src/collectors/kafkastat/kafkastat.py
@@ -140,7 +140,7 @@ class KafkaCollector(diamond.collector.Collector):
                     ptype = float
                 if type(aval).__name__ == int:
                     ptype = int
-                else
+                else:
                     continue
 
             value = ptype(aval)


### PR DESCRIPTION
Some stats types are labeld as 'java.lang.Object' in MX4J.
These stats are valuabe and get missed because we check for 'type' and
only use it if it matches double, float, long, or int.
Because of this we seem to miss all FetcherLagMetrics.
