### PR TITLE
Add Mogilefs collector

### DIFF
--- a/docs/collectors/MogilefsCollector.md
+++ b/docs/collectors/MogilefsCollector.md
@@ -1,0 +1,32 @@
+<!--This file was generated from the python source
+Please edit the source to make changes
+-->
+MogilefsCollector
+=====
+
+Collect statistics from Mogilefs
+
+#### Dependencies
+
+ * telnetlib
+ * time
+
+
+
+#### Options
+
+Setting | Default | Description | Type
+--------|---------|-------------|-----
+byte_unit | byte | Default numeric output(s) | str
+enabled | False | Enable collecting these metrics | bool
+measure_collector_time | False | Collect the collector run time in ms | bool
+metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
+metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
+path | mogilefs | Metric path | str
+
+#### Example Output
+
+```
+__EXAMPLESHERE__
+```
+

--- a/src/collectors/mogilefs/mogilefs.py
+++ b/src/collectors/mogilefs/mogilefs.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+
+"""
+Collect statistics from Mogilefs
+
+#### Dependencies
+
+ * telnetlib
+ * time
+
+
+"""
+import diamond.collector
+import telnetlib
+import time
+
+
+class MogilefsCollector(diamond.collector.Collector):
+
+    def get_default_config_help(self):
+        config_help = super(MogilefsCollector, self).get_default_config_help()
+        config_help.update({
+            'path': 'Metric path',
+        })
+        return config_help
+
+    def get_default_config(self):
+        config = super(MogilefsCollector, self).get_default_config()
+        config.update({
+            'path':     'mogilefs'
+        })
+        return config
+
+    def collect(self):
+        tn = telnetlib.Telnet("127.0.0.1", 7001, 3)
+        time.sleep(1)
+        tn.write("!stats" + '\r\n')
+        out = tn.read_until('.', 3)
+
+        myvars = {}
+
+        for line in out.splitlines()[:-1]:
+            name, var = line.partition(" ")[::2]
+            myvars[name.strip()] = long(var)
+
+        for key, value in myvars.iteritems():
+            # Set Metric Name
+            metric_name = key
+            # Set Metric Value
+            metric_value = value
+            # Publish Metric
+            self.publish(metric_name, metric_value)

--- a/src/collectors/mogilefs/test/fixtures/stats
+++ b/src/collectors/mogilefs/test/fixtures/stats
@@ -1,0 +1,11 @@
+uptime 181491
+pending_queries 0
+processing_queries 1
+bored_queryworkers 49
+queries 4353158
+times_out_of_qworkers 2
+work_queue_for_delete 2
+work_queue_for_replicate 0
+work_sent_to_delete 336154
+work_sent_to_replicate 274882
+.

--- a/src/collectors/mogilefs/test/testmogilefs.py
+++ b/src/collectors/mogilefs/test/testmogilefs.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock, call
+from mock import patch
+
+from diamond.collector import Collector
+
+from mogilefs import MogilefsCollector
+
+################################################################################
+
+
+class TestMogilefsCollector(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('MogilefsCollector', {
+            'interval': 10
+        })
+
+        self.collector = MogilefsCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(MogilefsCollector)
+
+    @patch.object(Collector, 'publish')
+    def test_stub_data(self, publish_mock):
+
+        mockTelnet = Mock(**{'read_until.return_value':
+                             self.getFixture('stats').getvalue()})
+
+        patch_Telnet = patch('telnetlib.Telnet', Mock(return_value=mockTelnet))
+
+        patch_Telnet.start()
+        self.collector.collect()
+        patch_Telnet.stop()
+
+        mockTelnet.read_until.assert_any_call('.', 3)
+
+        metrics = {
+            'uptime': 181491,
+            'pending_queries': 0,
+            'processing_queries': 1,
+            'bored_queryworkers': 49,
+            'queries': 4353158,
+            'times_out_of_qworkers': 2,
+            'work_queue_for_delete': 2,
+            'work_queue_for_replicate': 0,
+            'work_sent_to_delete': 336154,
+            'work_sent_to_replicate': 274882
+        }
+
+        self.assertPublishedMany(publish_mock, metrics)
+
+################################################################################
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This collector collect stats from mogilefs tracker:

```
# telnet localhost 7001
Trying ::1...
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
!stats
uptime 181491
pending_queries 0
processing_queries 1
bored_queryworkers 49
queries 4353158
times_out_of_qworkers 2
work_queue_for_delete 2
work_queue_for_replicate 0
work_sent_to_delete 336154
work_sent_to_replicate 274882
```
