### PR TITLE
Add support to jbossapi to fetch thread pool statistics

### DIFF
--- a/docs/collectors/JbossApiCollector.md
+++ b/docs/collectors/JbossApiCollector.md
@@ -60,7 +60,7 @@ jvm_buffer_pool_stats = True | False
 jvm_memory_pool_stats = True | False
 jvm_gc_stats = True | False
 jvm_thread_stats = True | False
-
+thread_pool_stats = True | False
 
 
 #### Options
@@ -78,14 +78,20 @@ jvm_buffer_pool_stats | True | Collect JVM buffer-pool stats | str
 jvm_gc_stats | True | Collect JVM garbage-collector stats | str
 jvm_memory_pool_stats | True | Collect JVM memory-pool stats | str
 jvm_memory_stats | True | Collect JVM basic memory stats | str
-jvm_thread_stats | True | Collect JVM thread stas | str
+jvm_thread_stats | True | Collect JVM thread stats | str
 measure_collector_time | False | Collect the collector run time in ms | bool
 metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
 metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
+thread_pool_stats | True | Collect thread pool stats defined by the JBoss threading subsystem | str
 
 #### Example Output
 
 ```
-__EXAMPLESHERE__
+servers.hostname.jboss.application.thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.largest-thread-count 19
+servers.hostname.jboss.application.thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.current-thread-count 19
+servers.hostname.jboss.application.thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.queue-size 0
+servers.hostname.jboss.application.thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.queue-length 25
+servers.hostname.jboss.application.thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.rejected-count 0
+servers.hostname.jboss.application.thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.max-threads 20
 ```
 

--- a/src/collectors/jbossapi/jbossapi.py
+++ b/src/collectors/jbossapi/jbossapi.py
@@ -80,8 +80,8 @@ operational_type = [
     'app',
     'web',
     'jvm',
+    'thread_pool',
 ]
-
 
 web_stats = [
     'errorCount',
@@ -153,7 +153,8 @@ class JbossApiCollector(diamond.collector.Collector):
             'jvm_buffer_pool_stats': 'Collect JVM buffer-pool stats',
             'jvm_memory_stats': 'Collect JVM basic memory stats',
             'jvm_gc_stats': 'Collect JVM garbage-collector stats',
-            'jvm_thread_stats': 'Collect JVM thread stas',
+            'jvm_thread_stats': 'Collect JVM thread stats',
+            'thread_pool_stats': 'Collect JBoss thread pool stats',
             'connector_stats': 'Collect HTTP and AJP Connector stats',
             'connector_options': 'Types of connectors to collect'
         })
@@ -178,7 +179,8 @@ class JbossApiCollector(diamond.collector.Collector):
             'jvm_memory_stats': 'True',
             'jvm_gc_stats': 'True',
             'jvm_thread_stats': 'True',
-            'connector_stats': 'True'
+            'connector_stats': 'True',
+            'thread_pool_stats': 'True'
         })
         # Return default config
         return config
@@ -214,6 +216,21 @@ class JbossApiCollector(diamond.collector.Collector):
                             metricValue = datasource[
                                 'statistics']['pool'][metric]
                             self.publish(metricName, float(metricValue))
+
+            if (op_type == 'thread_pool' and
+                    self.config['thread_pool_stats'] == 'True' and output):
+                # Grab the stats from each thread pool type
+                for pool_type in output['result']:
+                    if output['result'][pool_type]:
+                        pool_types = output['result'][pool_type]
+                        for pool in pool_types:
+                            for metric in pool_types[pool]:
+                                metricName = '%s.%s.%s.%s.statistics.%s' % (
+                                    interface, op_type, pool_type,
+                                    pool, metric)
+                                metricValue = pool_types[pool][metric]
+                                if self.is_number(metricValue):
+                                    self.publish(metricName, float(metricValue))
 
             if op_type == 'web' and self.config['connector_stats'] == 'True':
                 if output:
@@ -312,6 +329,10 @@ class JbossApiCollector(diamond.collector.Collector):
                     '"recursive":"true", ' +
                     '"address":["subsystem","datasources"]}')
 
+        if op_type == 'thread_pool':
+            data = ('{"operation":"read-resource", "include-runtime":"true", ' +
+                    '"recursive":"true" , "address":["subsystem","threads"]}')
+
         if op_type == 'web':
             data = ('{"operation":"read-resource", ' +
                     '"include-runtime":"true", ' +
@@ -340,6 +361,10 @@ class JbossApiCollector(diamond.collector.Collector):
             self.log.error("JbossApiCollector: There was an exception %s", e)
             output = ''
         return output
+
+    def is_number(self, value):
+        return (isinstance(value, (int, long, float)) and
+                not isinstance(value, bool))
 
     def string_fix(self, s):
         return re.sub(r"[^a-zA-Z0-9_]", "_", s)


### PR DESCRIPTION
This PR add support to collect  the thread pool statistics from the threads subsystem management API.

See: https://github.com/python-diamond/Diamond/issues/517

For example:

```
thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.current-thread-count 18
thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.max-threads 20
thread_pool.bounded-queue-thread-pool.ajp-executor.statistics.rejected-count 0
```
