### PR TITLE
Return numeric OID for SNMP - not pretty version

### DIFF
--- a/src/collectors/snmp/snmp.py
+++ b/src/collectors/snmp/snmp.py
@@ -90,7 +90,7 @@ class SNMPCollector(diamond.collector.Collector):
         # TODO: Error check
 
         for o, v in varBind:
-            ret[o.prettyPrint()] = v.prettyPrint()
+            ret[str(o)] = v.prettyPrint()
 
         return ret
 
@@ -127,6 +127,6 @@ class SNMPCollector(diamond.collector.Collector):
 
         for varBindTableRow in varBindTable:
             for o, v in varBindTableRow:
-                ret[o.prettyPrint()] = v.prettyPrint()
+                ret[str(o)] = v.prettyPrint()
 
         return ret


### PR DESCRIPTION
Using the SNMPRawCollector fails because it is expecting the return from the snmp collector in numeric OID not prettied up OID:

This solves #519
