### PR TITLE
add https support to elasticsearch collector without breaking existing configs

### DIFF
--- a/docs/collectors/ElasticSearchCollector.md
+++ b/docs/collectors/ElasticSearchCollector.md
@@ -28,6 +28,7 @@ measure_collector_time | False | Collect the collector run time in ms | bool
 metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
 metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
 port | 9200 |  | int
+scheme | http | http (default) or https | str
 stats | jvm, thread_pool, indices, | Available stats:<br>
  - jvm (JVM information)<br>
  - thread_pool (Thread pool information)<br>

--- a/docs/collectors/ElasticSearchCollector.md
+++ b/docs/collectors/ElasticSearchCollector.md
@@ -20,6 +20,7 @@ parameter the instance alias will be appended to the
 Setting | Default | Description | Type
 --------|---------|-------------|-----
 byte_unit | byte | Default numeric output(s) | str
+cluster | False | cluster/node/shard health | bool
 enabled | False | Enable collecting these metrics | bool
 host | 127.0.0.1 |  | str
 instances | , | List of instances. When set this overrides the 'host' and 'port' settings. Instance format: instance [<alias>@]<hostname>[:<port>] | list

--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -415,6 +415,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
             self.log.error('Unable to import json')
             return {}
 
+        scheme = self.config['scheme']
         for alias in sorted(self.instances):
             (host, port) = self.instances[alias]
             self.collect_instance(alias, scheme, host, port)

--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -226,7 +226,8 @@ class ElasticSearchCollector(diamond.collector.Collector):
                                 index['primaries'])
 
     def collect_instance(self, alias, scheme, host, port):
-        result = self._get(scheme, host, port, '_nodes/_local/stats?all=true', 'nodes')
+        result = self._get(scheme, host, port,
+                           '_nodes/_local/stats?all=true', 'nodes')
         if not result:
             return
 

--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -68,6 +68,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
             "the 'host' and 'port' settings. Instance format: "
             "instance [<alias>@]<hostname>[:<port>]",
             'scheme': "http (default) or https",
+            'cluster': "cluster/node/shard health",
             'stats':
                 "Available stats:\n" +
                 " - jvm (JVM information)\n" +


### PR DESCRIPTION
ElasticSearch now has SSL/TLS/HTTPS support via several means: Shield, SearchGuard. 

This patch allows specifying the connection scheme which was previously hardcoded as HTTP. 

The default scheme is still HTTP but now it can also be specified as HTTPS.