### PR TITLE
make userscripts collector error messages sane

### DIFF
--- a/src/collectors/userscripts/userscripts.py
+++ b/src/collectors/userscripts/userscripts.py
@@ -82,7 +82,7 @@ class UserScriptsCollector(diamond.collector.Collector):
                 self.log.info("%s return no output" % absolutescriptpath)
                 continue
             if err:
-                self.log.error("%s return error output: %s" %
+                self.log.error("%s returned error output (stderr): %s" %
                                (absolutescriptpath, err))
             # Use filter to remove empty lines of output
             for line in filter(None, out.split('\n')):
@@ -91,7 +91,7 @@ class UserScriptsCollector(diamond.collector.Collector):
                     name, value = line.split()
                     float(value)
                 except ValueError:
-                    self.log.error("%s returned error output: %s" %
+                    self.log.error("%s returned invalid/unparsable output: %s" %
                                    (absolutescriptpath, line))
                     continue
                 name, value = line.split()


### PR DESCRIPTION
we have 2 almost identical error outputs - one when stderr contains something, and another when stdout contains something we couldn't split.   if you don't notice the "d" difference, debugging the result is near impossible.

changed the errors to reflect the actual conditions.
