### PR TITLE
set example configs to use a better log format 

### DIFF
--- a/conf/diamond.conf.example
+++ b/conf/diamond.conf.example
@@ -240,7 +240,7 @@ args = ('/var/log/diamond/diamond.log', 'midnight', 1, 7)
 
 [formatter_default]
 
-format = [%(asctime)s] [%(threadName)s] %(message)s
+format = [%(asctime)s] [%(levelname)s] [%(threadName)s:%(processName)s] %(message)s
 datefmt =
 
 ################################################################################

--- a/docs/Getting-Started/Configuration.md
+++ b/docs/Getting-Started/Configuration.md
@@ -57,7 +57,7 @@ formatter = default
 args = ('/var/log/diamond/diamond.log', 'midnight', 1, 7)
 
 [formatter_default]
-format = [%(asctime)s] [%(threadName)s] %(message)s
+format = [%(asctime)s] [%(levelname)s] [%(threadName)s:%(processName)s] %(message)s
 datefmt =
 ```
 
@@ -86,7 +86,7 @@ For example, a collector called *examplecollector.ExampleCollector* could have i
 
 Example:
 Enable HttpdCollector
-Create a file HttpdCollector.conf and set 
+Create a file HttpdCollector.conf and set
 ```
 enabled = True
 ```


### PR DESCRIPTION
the example main log format uses a format that throws away the collector and loglevel information.

In the past years I've probably burned a solid month trying to debug problems that would have be much easier if I knew what collector was actually firing the message.

Running with `-l` uses a different format that contains more of the useful information.

current log format example:

```
[2016-09-21 21:02:04,639] [MainThread] ATTRIBUTE_NAME not found in second column of smartctl output between lines 4 and 9.
[2016-09-21 21:02:04,639] [MainThread] Collection took 11 ms
[2016-09-21 21:02:06,836] [MainThread] Ignoring / since it is of type rootfs  which is not in the list of filesystems.
[2016-09-21 21:02:06,837] [MainThread] Ignoring /proc since it is of type proc  which is not in the list of filesystems.
[2016-09-21 21:02:06,837] [MainThread] Ignoring /sys since it is of type sysfs  which is not in the list of filesystems.
[2016-09-21 21:02:06,837] [MainThread] Ignoring /dev since it is of type devtmpfs  which is not in the list of filesystems.
[2016-09-21 21:02:06,837] [MainThread] Ignoring /dev/pts since it is of type devpts  which is not in the list of filesystems.
[2016-09-21 21:02:06,837] [MainThread] Ignoring /dev/shm since it is of type tmpfs  which is not in the list of filesystems.
[2016-09-21 21:02:06,837] [MainThread] Ignoring /proc/bus/usb since it is of type usbfs  which is not in the list of filesystems.
[2016-09-21 21:02:06,837] [MainThread] Ignoring /proc/sys/fs/binfmt_misc since it is of type binfmt_misc  which is not in the list of filesystems.
[2016-09-21 21:02:06,840] [MainThread] Collection took 3 ms
[2016-09-21 21:02:07,276] [MainThread] Collection took 1 ms
[2016-09-21 21:02:09,549] [MainThread] Collection took 1 ms
[2016-09-21 21:02:13,978] [MainThread] Collection took 6 ms
[2016-09-21 21:02:20,573] [MainThread] Collection took 3 ms
[2016-09-21 21:02:25,707] [MainThread] Executing command: /usr/bin/redislabs_cli graphite_metrics
[2016-09-21 21:02:25,788] [MainThread] /usr/bin/redislabs_cli graphite_metrics return exit value 1; skipping
[2016-09-21 21:02:25,789] [MainThread] /usr/bin/redislabs_cli graphite_metrics returned no output
[2016-09-21 21:02:25,789] [MainThread] Collection took 81 ms
```

Example of the proposed format:

```
[2016-09-21 21:05:13,676] [MainThread:DiskSpaceCollector:DEBUG] Starting
[2016-09-21 21:05:13,676] [MainThread:DiskSpaceCollector:DEBUG] Interval: 30.0 seconds
[2016-09-21 21:05:13,676] [MainThread:DiskSpaceCollector:DEBUG] Max collection time: 23 seconds
[2016-09-21 21:05:13,677] [MainThread:DiskSpaceCollector:DEBUG] Ignoring / since it is of type rootfs  which is not in the list of filesystems.
[2016-09-21 21:05:13,677] [MainThread:DiskSpaceCollector:DEBUG] Ignoring /proc since it is of type proc  which is not in the list of filesystems.
[2016-09-21 21:05:13,677] [MainThread:DiskSpaceCollector:DEBUG] Ignoring /sys since it is of type sysfs  which is not in the list of filesystems.
[2016-09-21 21:05:13,677] [MainThread:DiskSpaceCollector:DEBUG] Ignoring /dev since it is of type devtmpfs  which is not in the list of filesystems.
[2016-09-21 21:05:13,677] [MainThread:DiskSpaceCollector:DEBUG] Ignoring /dev/pts since it is of type devpts  which is not in the list of filesystems.
[2016-09-21 21:05:13,677] [MainThread:DiskSpaceCollector:DEBUG] Ignoring /dev/shm since it is of type tmpfs  which is not in the list of filesystems.
[2016-09-21 21:05:13,677] [MainThread:DiskSpaceCollector:DEBUG] Ignoring /proc/bus/usb since it is of type usbfs  which is not in the list of filesystems.
[2016-09-21 21:05:13,677] [MainThread:DiskSpaceCollector:DEBUG] Ignoring /proc/sys/fs/binfmt_misc since it is of type binfmt_misc  which is not in the list of filesystems.
[2016-09-21 21:05:17,714] [MainThread:SmartCollector:DEBUG] Starting
[2016-09-21 21:05:17,714] [MainThread:SmartCollector:DEBUG] Interval: 30.0 seconds
[2016-09-21 21:05:17,714] [MainThread:SmartCollector:DEBUG] Max collection time: 16 seconds
[2016-09-21 21:05:17,738] [MainThread:SmartCollector:WARNING] ATTRIBUTE_NAME not found in second column of smartctl output between lines 4 and 9.
[2016-09-21 21:05:17,738] [MainThread:SmartCollector:DEBUG] Collection took 23 ms
[2016-09-21 21:05:18,452] [MainThread:RedisLabsCollector:DEBUG] Executing command: /usr/bin/redislabs_cli graphite_metrics
[2016-09-21 21:05:18,534] [MainThread:RedisLabsCollector:ERROR] /usr/bin/redislabs_cli graphite_metrics return exit value 1; skipping
[2016-09-21 21:05:18,534] [MainThread:RedisLabsCollector:INFO] /usr/bin/redislabs_cli graphite_metrics returned no output
[2016-09-21 21:05:18,534] [MainThread:RedisLabsCollector:DEBUG] Collection took 82 ms
```
