### PR TITLE
fix error handling output for userscripts collector

### DIFF
--- a/src/collectors/userscripts/userscripts.py
+++ b/src/collectors/userscripts/userscripts.py
@@ -76,14 +76,14 @@ class UserScriptsCollector(diamond.collector.Collector):
                                (absolutescriptpath, e))
                 continue
             if proc.returncode:
-                self.log.error("%s return exit value %s; skipping" %
+                self.log.error("%s return exit value %s" %
                                (absolutescriptpath, proc.returncode))
+            if err:
+                self.log.warning("%s return error output: %s" %
+                               (absolutescriptpath, err))
             if not out:
                 self.log.info("%s return no output" % absolutescriptpath)
                 continue
-            if err:
-                self.log.error("%s return error output: %s" %
-                               (absolutescriptpath, err))
             # Use filter to remove empty lines of output
             for line in filter(None, out.split('\n')):
                 # Ignore invalid lines


### PR DESCRIPTION
another fix for error cases:  

before: if stderr is returned, but no stdout, we bail out before we report the stderr content - throwing away the error message that may only be reproducible in the conditions of the collector.

after:  if stderr is returned, log it regardless of if we bail.   log it as warning, not error, since it's non-blocking.
 
also removed "skipping" from the proc.returncode - we dont actually bail unless there's no stdout, regardless of return code, so dont tell the user we are.