### PR TITLE
calculate available space based on available blocks instead of free blocks

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -239,8 +239,9 @@ class DiskSpaceCollector(diamond.collector.Collector):
 
             for unit in self.config['byte_unit']:
                 metric_name = '%s.%s_percentfree' % (name, unit)
-                metric_value = float(blocks_free) / float(
-                    blocks_free + (blocks_total - blocks_free)) * 100
+
+                ## report same values like df output aka. percentfree available to non-super user
+                metric_value = float(blocks_avail) * 100 / float(blocks_total)
                 self.publish_gauge(metric_name, metric_value, 2)
 
                 metric_name = '%s.%s_used' % (name, unit)


### PR DESCRIPTION
Hi, the current computation for available space uses the amount of free blocks instead of available blocks which may not always be a good idea because free blocks include blocks which can exclusively be used by root.
