### PR TITLE
Remove invalid params as of ES 5.0

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -206,9 +206,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
         metrics['cluster_health.status'] = CLUSTER_STATUS[result['status']]
 
     def collect_instance_index_stats(self, scheme, host, port, metrics):
-        result = self._get(scheme, host, port,
-                           '_stats?clear=true&docs=true&store=true&' +
-                           'indexing=true&get=true&search=true', '_all')
+        result = self._get(scheme, host, port, '_stats', '_all')
         if not result:
             return
 
@@ -227,8 +225,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
                                 index['primaries'])
 
     def collect_instance(self, alias, scheme, host, port):
-        result = self._get(scheme, host, port,
-                           '_nodes/_local/stats?all=true', 'nodes')
+        result = self._get(scheme, host, port, '_nodes/_local/stats', 'nodes')
         if not result:
             return
 


### PR DESCRIPTION
As of Elasticsearch 1.0 the format of of the APIs have changed to a more RESTful format. Furthermore, as of Elasticsearch 5.0, erroneous URL params are rejected. This is causing the collector to fail for ES 5.0+. Previously ES would ignore bad params, and thus these changes went unnoticed.

Indices stats API now returns all by default, no need to specify additional params, as of 1.3:
https://www.elastic.co/guide/en/elasticsearch/reference/1.3/indices-stats.html

Similarly, the node stats API will also return all by default as 1.3:
https://www.elastic.co/guide/en/elasticsearch/reference/1.3/cluster-nodes-stats.html

ES 5.0 behavior change:
https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_rest_api_changes.html#_strict_rest_query_string_parameter_parsing

Changes have been validated against 2.0+. Haven't been able to test earlier than that, but I assume this is good at least as far back as 1.3.