### PR TITLE
Shutdown GraphiteHandler socket connection before closing

### DIFF
--- a/src/diamond/handler/graphite.py
+++ b/src/diamond/handler/graphite.py
@@ -255,5 +255,6 @@ class GraphiteHandler(Handler):
         Close the socket
         """
         if self.socket is not None:
+            self.socket.shutdown(socket.SHUT_RDWR)
             self.socket.close()
         self.socket = None


### PR DESCRIPTION
Without shutting down the socket before closing, with carbon-relay behind an Amazon EC2 ELB,
Diamond can get stuck in an inconsistent state where sockets are kept open in a CLOSE-WAIT
state.

For example, we let two nodes running Diamond report metrics to carbon-relay behind an ELB over a period
of 24 hours with the following parameters:
- node01 - running Diamond with the socket shutdown logic added (this PR)
- node02 - running Diamond without the socket shutdown logic added

Partway into the test (16:52), we observed that node02 stopped reporting metrics:

<img width="829" alt="screen shot 2016-11-25 at 11 28 58" src="https://cloud.githubusercontent.com/assets/982046/20625003/3698277a-b308-11e6-8e9a-01180a53ad72.png">

Upon checking the logs, we see the following errors on node02 but NOT node01:

   [2016-11-24 16:52:27,915] [MainThread] GraphiteHandler: Socket error, trying reconnect.
   [2016-11-24 17:00:43,056] [MainThread] GraphiteHandler: Socket error, trying reconnect.
   [2016-11-24 17:02:43,045] [MainThread] GraphiteHandler: Socket error, trying reconnect.
   [2016-11-24 17:06:52,968] [MainThread] GraphiteHandler: Socket error, trying reconnect.

This coincides exactly with the time that the node stopped reporting metrics in to carbon.

When checking the socket status on that node with `ss`, we see the following:

```
root@node02:~# ss -ntp | grep diam
CLOSE-WAIT 1      0             172.20.244.54:45725        10.20.255.252:2004   users:(("diamond",12826,4),("diamond",12812,4),("diamond",12803,4),("diamond",12795,4),("diamond",12792,4),("diamond",12786,4),("diamond",12750,4))
CLOSE-WAIT 1      0             172.20.244.54:49532        10.20.255.233:2004   users:(("diamond",12780,4))
```

For reference, following is the `pstree` output for Diamond processes:

```
        ├─diamond(12750)─┬─diamond(12753)─┬─{diamond}(12782)
        │                │                ├─{diamond}(12788)
        │                │                ├─{diamond}(12814)
        │                │                ├─{diamond}(12828)
        │                │                ├─{diamond}(12853)
        │                │                ├─{diamond}(12854)
        │                │                └─{diamond}(12855)
        │                ├─diamond(12780)
        │                ├─diamond(12786)
        │                ├─diamond(12792)
        │                ├─diamond(12795)
        │                ├─diamond(12803)
        │                ├─diamond(12812)
        │                └─diamond(12826)
```

However, on node01 which has the socket shutdown fix, we see the following sockets open:

```
root@node01:~# ss -ntp | grep diam
ESTAB      0      0            172.20.245.210:52872        10.20.255.252:2004   users:(("diamond",19942,4))
```

node01 was able to report metrics for the duration of the test.