### PR TITLE
Set a proper email address in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
     version=version,
     url='https://github.com/python-diamond/Diamond',
     author='The Diamond Team',
-    author_email='https://github.com/python-diamond/Diamond',
+    author_email='diamond@librelist.com',
     license='MIT License',
     description='Smart data producer for graphite graphing package',
     package_dir={'': 'src'},


### PR DESCRIPTION
This should fix issues uploading the package to twine, as per https://github.com/h5py/h5py/commit/0efaceeffb3693a4dd1ef0cd60b93d74c870cee0

/cc @kormoc @jaingaurav in case you have an email you'd prefer this go this. For me, it's just a catchall.