### PR TITLE
Ensure we call `make clean` to remove pyc files from build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ reltest:
 distrotest:
 	echo ${DISTRO}
 
-pypi: version sdist bdist_wheel
+pypi: clean version sdist bdist_wheel
 	twine upload -s dist/*
 	git tag "v$(shell cat version.txt)"
 	git push --tags


### PR DESCRIPTION
Closes #493