### PR TITLE
Change deprecated psutil memory_info_ex to memory_info

### DIFF
--- a/docs/collectors/ProcessResourcesCollector.md
+++ b/docs/collectors/ProcessResourcesCollector.md
@@ -14,7 +14,7 @@ Example config file ProcessResourcesCollector.conf
 enabled=True
 unit=B
 cpu_interval=0.1
-info_keys='num_ctx_switches','cpu_percent','cpu_times','io_counters','num_threads','num_fds','memory_percent','memory_info_ex'
+info_keys='num_ctx_switches','cpu_percent','cpu_times','io_counters','num_threads','num_fds','memory_percent','memory_info'
 [process]
 [[postgres]]
 exe=^\/usr\/lib\/postgresql\/+d.+d\/bin\/postgres$
@@ -40,7 +40,7 @@ Setting | Default | Description | Type
 --------|---------|-------------|-----
 byte_unit | byte | Default numeric output(s) | str
 enabled | False | Enable collecting these metrics | bool
-info_keys | num_ctx_switches, cpu_percent, cpu_times, io_counters, num_threads, num_fds, memory_percent, memory_info_ex, | List of process metrics to collect. Valid list of metrics can be found [here](https://pythonhosted.org/psutil/) | list
+info_keys | num_ctx_switches, cpu_percent, cpu_times, io_counters, num_threads, num_fds, memory_percent, memory_info, | List of process metrics to collect. Valid list of metrics can be found [here](https://pythonhosted.org/psutil/) | list
 measure_collector_time | False | Collect the collector run time in ms | bool
 metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
 metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType

--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -11,7 +11,7 @@ Example config file ProcessResourcesCollector.conf
 enabled=True
 unit=B
 cpu_interval=0.1
-info_keys='num_ctx_switches','cpu_percent','cpu_times','io_counters','num_threads','num_fds','memory_percent','memory_info_ex'
+info_keys='num_ctx_switches','cpu_percent','cpu_times','io_counters','num_threads','num_fds','memory_percent','memory_info'
 [process]
 [[postgres]]
 exe=^\/usr\/lib\/postgresql\/+d.+d\/bin\/postgres$
@@ -142,7 +142,7 @@ class ProcessResourcesCollector(diamond.collector.Collector):
         Default settings are:
             info_keys: ['num_ctx_switches', 'cpu_percent', 'cpu_times',
                         'io_counters', 'num_threads', 'num_fds',
-                        'memory_percent', 'memory_info_ex', ]
+                        'memory_percent', 'memory_info', ]
             path: 'process'
             unit: 'B'
         """
@@ -150,7 +150,7 @@ class ProcessResourcesCollector(diamond.collector.Collector):
         config.update({
             'info_keys': ['num_ctx_switches', 'cpu_percent', 'cpu_times',
                           'io_counters', 'num_threads', 'num_fds',
-                          'memory_percent', 'memory_info_ex', ],
+                          'memory_percent', 'memory_info', ],
             'path': 'process',
             'unit': 'B',
             'process': {},

--- a/src/collectors/processresources/test/testprocessresources.py
+++ b/src/collectors/processresources/test/testprocessresources.py
@@ -183,7 +183,7 @@ class TestProcessResourcesCollector(CollectorTestCase):
                     'username': 'root',
                     'cpu_times': cputimes(user=0.27, system=1.05),
                     'io_counters': None,
-                    'memory_info_ex': ext_meminfo(rss=self.rss,
+                    'memory_info': ext_meminfo(rss=self.rss,
                                                   vms=self.vms,
                                                   shared=1310720,
                                                   text=188416,
@@ -220,13 +220,13 @@ class TestProcessResourcesCollector(CollectorTestCase):
         patch_psutil_process_iter.stop()
         self.assertPublished(publish_mock, 'foo.uptime', 1234567890)
         self.assertPublished(publish_mock, 'foo.num_fds', 10)
-        self.assertPublished(publish_mock, 'postgres.memory_info_ex.rss',
+        self.assertPublished(publish_mock, 'postgres.memory_info.rss',
                              1000000 + 100000 + 10000 + 1000 + 100)
-        self.assertPublished(publish_mock, 'foo.memory_info_ex.rss', 1)
-        self.assertPublished(publish_mock, 'bar.memory_info_ex.rss', 3)
-        self.assertPublished(publish_mock, 'barexe.memory_info_ex.rss', 3)
+        self.assertPublished(publish_mock, 'foo.memory_info.rss', 1)
+        self.assertPublished(publish_mock, 'bar.memory_info.rss', 3)
+        self.assertPublished(publish_mock, 'barexe.memory_info.rss', 3)
         self.assertPublished(publish_mock,
-                             'diamond-selfmon.memory_info_ex.rss', 1234)
+                             'diamond-selfmon.memory_info.rss', 1234)
         self.assertPublished(publish_mock, 'noprocess.workers_count', 0)
         self.assertUnpublished(publish_mock, 'noprocess.uptime', 0)
 


### PR DESCRIPTION
psutil memory_info_ex method is deprecated:

https://pythonhosted.org/psutil/#psutil.Process.memory_info_ex

This PR changes memory_info_ex to memory_info.