### PR TITLE
do not derivative status.Uptime metrics

### DIFF
--- a/src/collectors/mysqlstat/mysqlstat.py
+++ b/src/collectors/mysqlstat/mysqlstat.py
@@ -62,6 +62,7 @@ class MySQLCollector(diamond.collector.Collector):
         'Slave_open_temp_tables',
         'Threads_cached', 'Threads_connected', 'Threads_created',
         'Threads_running',
+        'Uptime', 'Uptime_since_flush_status',
         # innodb status non counter keys
         'Innodb_bp_created_per_sec',
         'Innodb_bp_pages_evicted_no_access_per_sec',


### PR DESCRIPTION
uptime metrics should usually increase in linearity way, and drop to 0 when restart.
derivative() will just hide the information we care about.


if call `derivative`, metrics valudes are etheir 0 or 1
![image](https://cloud.githubusercontent.com/assets/3284451/21087618/834cc96a-c062-11e6-99b4-82bb99210c6a.png)
