### PR TITLE
Bind collector: Adding support for new some v3 XML bind9 stats and JSON v1

### DIFF
--- a/src/collectors/bind/bind.py
+++ b/src/collectors/bind/bind.py
@@ -35,6 +35,10 @@ class BindCollector(diamond.collector.Collector):
             " - memory (Global memory usage)\n",
             'publish_view_bind': "",
             'publish_view_meta': "",
+            'data_format': "Bind stats version:\n" +
+            " - xml_v2 (Original bind stats version from 9.5)\n" +
+            " - xml_v3 (New xml version)\n" +
+            " - json_v1 (JSON replacement for XML)\n",
         })
         return config_help
 
@@ -63,6 +67,7 @@ class BindCollector(diamond.collector.Collector):
             # By default we don't publish these special views
             'publish_view_bind': False,
             'publish_view_meta': False,
+            'data_format': 'xml',
         })
         return config
 
@@ -73,7 +78,63 @@ class BindCollector(diamond.collector.Collector):
         self.publish(name, value)
 
     def collect(self):
+        if self.config['data_format'] == 'json_v1':
+            return self.collect_json_v1()
+        if self.config['data_format'] == 'xml_v3':
+            return self.collect_xml_v3()
+        if self.config['data_format'] == 'xml':
+            return self.collect_xml_v2()
+
+    def collect_json_v1(self):
         try:
+            # Try newest interface first (JSON has least impact)
+            import json
+            req = urllib2.urlopen('http://%s:%d/json/v1/status' % (
+                self.config['host'], int(self.config['port'])))
+        except Exception, e:
+            self.log.error('JSON v1 not supported: %s', e)
+            return {}
+
+        if 'server' in self.config['publish']:
+            try:
+                req = urllib2.urlopen('http://%s:%d/json/v1/server' % (
+                    self.config['host'], int(self.config['port'])))
+            except Exception, e:
+                self.log.error('Couldnt connect to bind: %s', e)
+                return {}
+
+            response = json.load(req)
+            self.parse_json_v1_server(response)
+
+    def collect_xml_v3(self):
+        try:
+            # Try newer interface first
+            req = urllib2.urlopen('http://%s:%d/xml/v3/status' % (
+                self.config['host'], int(self.config['port'])))
+        except Exception, e:
+            self.log.error('XML v3 not supported: %s', e)
+            return {}
+
+        if 'server' in self.config['publish']:
+            try:
+                req = urllib2.urlopen('http://%s:%d/xml/v3/server' % (
+                    self.config['host'], int(self.config['port'])))
+            except Exception, e:
+                self.log.error('Couldnt connect to bind: %s', e)
+                return {}
+            # Proceed with v3 parsing
+            tree = ElementTree.parse(req)
+
+            if not tree:
+                raise ValueError("Corrupt XML file, no statistics found")
+
+            self.parse_xml_v3_server(tree)
+
+
+    def collect_xml_v2(self):
+        try:
+            # NOTE: Querying this node on a large server can impact bind answering queries
+            # for sometimes hundreds of milliseconds.
             req = urllib2.urlopen('http://%s:%d/' % (
                 self.config['host'], int(self.config['port'])))
         except Exception, e:
@@ -86,6 +147,9 @@ class BindCollector(diamond.collector.Collector):
             raise ValueError("Corrupt XML file, no statistics found")
 
         root = tree.find('bind/statistics')
+
+        if not root:
+            raise ValueError("Missing bind/statistics tree - Wrong data_format?")
 
         if 'resolver' in self.config['publish']:
             for view in root.findall('views/view'):
@@ -153,3 +217,37 @@ class BindCollector(diamond.collector.Collector):
                     'memory.%s' % counter.tag,
                     int(counter.text)
                 )
+
+    def parse_xml_v3_server(self, root):
+        for counters in root.findall('server/counters'):
+            for counter in counters:
+                self.clean_counter(
+                    'server.counters.%s.%s' % (counters.attrib['type'], counter.attrib['name']),
+                    int(counter.text)
+                )
+
+        for view in root.findall('views/view'):
+            for counters in view.iter('counters'):
+                for counter in counters:
+                    self.clean_counter(
+                        'views.%s.counters.%s.%s' % (view.attrib['name'], counters.attrib['type'], counter.attrib['name']),
+                        int(counter.text)
+                    )
+
+    def parse_json_v1_server(self, response):
+        for counter_metric_name in ['nsstat', 'opcode', 'qtype', 'rcode', 'zonestat']:
+            for counter in response[counter_metric_name+'s']:
+                self.clean_counter(
+                    'server.counters.%s.%s' % (counter_metric_name, counter),
+                    int(response[counter_metric_name+'s'][counter])
+                )
+
+        for view in response['views']:
+            for counters in response['views'][view]:
+                # This mapping maps from XML v3 layout to JSON v1
+                for section_name in response['views'][view]['resolver']:
+                    for counter in response['views'][view]['resolver'][section_name]:
+                        self.clean_counter(
+                            'views.%s.counters.%s.%s' % (view, section_name, counter),
+                            int(response['views'][view]['resolver'][section_name][counter])
+                            )


### PR DESCRIPTION
Bind 9.11 has removed the old XML (v2) interface. This adds some support for key statistics under /server section of new v3 XML and v1 JSON interface.

Querying the root of the XML interface can cause bind to stop answering queries for several hundred milliseconds. Querying /server XML only 4-5ms, and /server for JSON 1-2ms.