### PR TITLE
Adding an option to turn off derivatives of values for bind collector

### DIFF
--- a/docs/collectors/BindCollector.md
+++ b/docs/collectors/BindCollector.md
@@ -32,6 +32,7 @@ publish | resolver, server, zonemgmt, sockets, memory, | Available stats:<br>
  | list
 publish_view_bind | False |  | bool
 publish_view_meta | False |  | bool
+derivative | True | Report derived stats or raw (always incrementing) | bool
 
 #### Example Output
 

--- a/src/collectors/bind/bind.py
+++ b/src/collectors/bind/bind.py
@@ -13,6 +13,7 @@ Collects stats from bind 9.5's statistics server
 import diamond.collector
 import sys
 import urllib2
+from diamond.collector import str_to_bool
 
 if sys.version_info >= (2, 5):
     import xml.etree.cElementTree as ElementTree
@@ -63,13 +64,15 @@ class BindCollector(diamond.collector.Collector):
             # By default we don't publish these special views
             'publish_view_bind': False,
             'publish_view_meta': False,
+            'derivative': True,
         })
         return config
 
     def clean_counter(self, name, value):
-        value = self.derivative(name, value)
-        if value < 0:
-            value = 0
+        if str_to_bool(self.config['derivative']):
+            value = self.derivative(name, value)
+            if value < 0:
+                value = 0
         self.publish(name, value)
 
     def collect(self):


### PR DESCRIPTION
This means you can use graphite derivative or perSecond functions to get more accurate values over time