### PR TITLE
duplicate init files on rhel7 and rhel6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,16 +64,14 @@ else:
             data_files.append(('/etc/init',
                                ['debian/diamond.upstart']))
         if distro in ['centos', 'redhat', 'debian', 'fedora', 'oracle']:
-            data_files.append(('/etc/init.d',
-                               ['bin/init.d/diamond']))
             data_files.append(('/var/log/diamond',
                                ['.keep']))
             if distro_major_version >= 7 and not distro == 'debian':
                 data_files.append(('/usr/lib/systemd/system',
                                    ['rpm/systemd/diamond.service']))
-            elif distro_major_version >= 6 and not distro == 'debian':
-                data_files.append(('/etc/init',
-                                   ['rpm/upstart/diamond.conf']))
+            elif distro_major_version <= 6 and not distro == 'debian':
+                data_files.append(('/etc/init.d',
+                                   ['bin/init.d/diamond']))
 
     # Support packages being called differently on different distros
 


### PR DESCRIPTION
On RHEL6 both upstart and init.d were configured.
On RHEL7 both systemd and init.d were configured.
I also believe there is no need for using upstart on RHEL6, If you think there's a use for that, i'll fix my pull request.