### PR TITLE
add rpmspec option to not overwrite existing config files

### DIFF
--- a/rpm/install
+++ b/rpm/install
@@ -4,3 +4,9 @@
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif
+
+CONFIGFILES="
+%config(noreplace) /etc/diamond/*"
+echo "$CONFIGFILES" | cat INSTALLED_FILES - > INSTALLED_FILES.new
+mv INSTALLED_FILES.new INSTALLED_FILES
+


### PR DESCRIPTION
Mark all files in /etc/diamond as configuration files in rpm package.
When updating, rpm will not overwrite theses files if have been modified.