### PR TITLE
Fixed regex of WalSegmentStats

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -470,7 +470,7 @@ class WalSegmentStats(QueryStats):
     query = """
         SELECT count(*) AS segments
         FROM pg_ls_dir('pg_xlog') t(fn)
-        WHERE fn ~ '^[0-9A-Z]{{24}}\$'
+        WHERE fn ~ '^[0-9A-Z]{24}$'
     """
 
 


### PR DESCRIPTION
Regex pattern '^[0-9A-Z]{{24}}\$' is causing the following warning and result of query is always 0 on at least Postgresql 9.4-9.6.

```
HINT:  Use the escape string syntax for escapes, e.g., E'\r\n'.
WARNING:  nonstandard use of escape in a string literal at character 97
```

This change fixes the query. AFAICS this fix should not break with earlier versions of Postgresql but I could not test it.