### PR TITLE
Add Cython to TravisCI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 
 # command to install dependencies, e.g. pip install -r requirements.txt
 install:
+    - pip install Cython
     - pip install -r .travis.requirements.txt
     - pip install pep8==1.5.7
     - pip install coveralls


### PR DESCRIPTION
This should fix the Travis error:
```
Collecting pyutmp (from -r .travis.requirements.txt (line 16))
  Using cached pyutmp-0.2.1.zip
    sh: 1: cython: not found
    Failed to build "pyutmp_linux.c" from "pyutmp_linux.pyx"
    "pyutmp_linux.pyx" is newer than "pyutmp_linux.c". Rebuilding "pyutmp_linux.c".
    + cython pyutmp_linux.pyx
    Complete output from command python setup.py egg_info:
    sh: 1: cython: not found

    Failed to build "pyutmp_linux.c" from "pyutmp_linux.pyx"

    "pyutmp_linux.pyx" is newer than "pyutmp_linux.c". Rebuilding "pyutmp_linux.c".

    + cython pyutmp_linux.pyx

    ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-b6Ahv_/pyutmp
```