### PR TITLE
Diamond  centos7 service start

### DIFF
--- a/conf/diamond.conf.example
+++ b/conf/diamond.conf.example
@@ -17,7 +17,8 @@ user =
 # Leave empty to use the current group
 group =
 
-# Pid file
+# Pid file, on systemd if not using default PID file
+# make sure you also change systemd's diamond unit.
 pid_file = /var/run/diamond.pid
 
 # Directory to load collector modules from

--- a/rpm/systemd/diamond.service
+++ b/rpm/systemd/diamond.service
@@ -2,8 +2,9 @@
 Description=diamond - A system statistics collector for graphite
 
 [Service]
-ExecStart=/usr/bin/python /usr/bin/diamond -p /var/run/diamond.pid
+ExecStart=/usr/bin/python /usr/bin/diamond
 Type=forking
+#If not using default pid, make sure you change PIDFile setting
 PIDFile=/var/run/diamond.pid
 
 [Install]

--- a/rpm/systemd/diamond.service
+++ b/rpm/systemd/diamond.service
@@ -2,8 +2,9 @@
 Description=diamond - A system statistics collector for graphite
 
 [Service]
-ExecStart=/usr/bin/python /usr/bin/diamond --log-stdout --foreground
-Restart=on-abort
+ExecStart=/usr/bin/python /usr/bin/diamond -p /var/run/diamond.pid
+Type=forking
+PIDFile=/var/run/diamond.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Diamond on centos7 starts foreground and logging to stdout, also this options make diamond log in debug mode all the time. 

This PR starts Diamond the same way as in centos6/5