### PR TITLE
Revert "Adding Cython to the requirements"

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -13,7 +13,6 @@ pymongo<3.0
 # https://github.com/BrightcoveOS/Diamond/issues/650
 #pyrabbit
 statsd
-Cython
 pyutmp
 redis
 simplejson


### PR DESCRIPTION
This reverts commit 95c8786e8ccda084875fee4bc55d1eae2e8dc305.

Cython was added to `.travis.yml` file instead already