### PR TITLE
fix redis auth with /

### DIFF
--- a/src/collectors/redisstat/redisstat.py
+++ b/src/collectors/redisstat/redisstat.py
@@ -148,7 +148,7 @@ class RedisCollector(diamond.collector.Collector):
                 if '/' in hostport:
                     parts = hostport.split('/')
                     hostport = parts[0]
-                    auth = parts[1]
+                    auth = '/'.join(parts[1:])
                 else:
                     auth = None
 

--- a/src/collectors/redisstat/test/testredisstat.py
+++ b/src/collectors/redisstat/test/testredisstat.py
@@ -304,6 +304,33 @@ class TestRedisCollector(CollectorTestCase):
 
     @run_only_if_redis_is_available
     @patch.object(Collector, 'publish')
+    def test_process_config_with_instances(self, publish_mock):
+
+        config_data = {
+            'instances': [
+                'nick1@host1:1111',
+                'nick2@:2222',
+                'nick3@host3',
+                'nick4@host4:3333/@pass/word',
+                'bla'
+            ]
+        }
+
+        expected_processed_config = {
+            'nick2': ('localhost', 2222, None, None),
+            'nick3': ('host3', 6379, None, None),
+            'nick1': ('host1', 1111, None, None),
+            'nick4': ('host4', 3333, None, '@pass/word'),
+            '6379': ('bla', 6379, None, None)
+        }
+
+        config = get_collector_config('RedisCollector', config_data)
+        collector = RedisCollector(config, None)
+
+        self.assertEqual(collector.instances, expected_processed_config)
+
+    @run_only_if_redis_is_available
+    @patch.object(Collector, 'publish')
     def test_key_naming_when_using_instances(self, publish_mock):
 
         config_data = {


### PR DESCRIPTION
Since there is a split on `/`, the password join must handle a `/` in the password