### PR TITLE
Only build master branch for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,7 @@ notifications:
 addons:
     apt_packages:
     - libsensors4
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
This avoids double testing for PR's based on branches from the root repo
(1 test for branch and 1 test for PR)