### PR TITLE
Add linux raid (mdstat) collector

### DIFF
--- a/docs/collectors/MdStatCollector.md
+++ b/docs/collectors/MdStatCollector.md
@@ -5,12 +5,48 @@ MdStatCollector
 =====
 
 Collect linux RAID/md state by parsing /proc/mdstat.
-https://raid.wiki.kernel.org/index.php/Mdstat
+<https://raid.wiki.kernel.org/index.php/Mdstat>
 
 #### Dependencies
 
- * /proc/mdstat
+- /proc/mdstat
 
+#### Supported metrics
+
+```
+md0 : active raid1 sda1[0] sda2[2](S) sda3[1]
+```
+- member_count.active
+- member_count.faulty
+- member_count.spare
+
+```
+39058432 blocks super 1.2 level 5, 512k chunk, algorithm 2 [3/3] [UUU]
+199800 blocks super 1.2 999k rounding
+```
+- status.blocks
+- status.superblock_version
+- status.raid_level
+- status.chunk_size
+- status.algorithm
+- status.rounding_factor
+- status.actual_members
+- status.total_members
+
+```
+bitmap: 1/1 pages [4KB], 65536KB chunk
+```
+- bitmap.total_pages
+- bitmap.allocated_pages
+- bitmap.page_size
+
+```
+[===================>.]  recovery = 99.5% (102272/102272) finish=13.37min
+                         speed=102272K/sec
+```
+- recovery.percent
+- recovery.speed
+- recovery.remaining_time
 
 #### Options
 

--- a/docs/collectors/MdStatCollector.md
+++ b/docs/collectors/MdStatCollector.md
@@ -1,0 +1,44 @@
+<!--This file was generated from the python source
+Please edit the source to make changes
+-->
+MdStatCollector
+=====
+
+Collect linux RAID/md state by parsing /proc/mdstat.
+https://raid.wiki.kernel.org/index.php/Mdstat
+
+#### Dependencies
+
+ * /proc/mdstat
+
+
+#### Options
+
+Setting | Default | Description | Type
+--------|---------|-------------|-----
+byte_unit | byte | Default numeric output(s) | str
+device_filter | ^md[0-9]*$ | A regex pattern.Metrics will be collected for any md device matching the pattern | str
+enabled | False | Enable collecting these metrics | bool
+measure_collector_time | False | Collect the collector run time in ms | bool
+metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
+metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
+
+#### Example Output
+
+```
+servers.hostname.mdstat.md0.bitmap.allocated_pages 1
+servers.hostname.mdstat.md0.bitmap.chunk_size 65536
+servers.hostname.mdstat.md0.bitmap.page_size 4
+servers.hostname.mdstat.md0.bitmap.total_pages 1
+servers.hostname.mdstat.md0.member_count.active 2
+servers.hostname.mdstat.md0.member_count.faulty 0
+servers.hostname.mdstat.md0.member_count.spare 0
+servers.hostname.mdstat.md0.recovery.percent 99.5
+servers.hostname.mdstat.md0.recovery.remaining_time 802199
+servers.hostname.mdstat.md0.recovery.speed 104726528
+servers.hostname.mdstat.md0.status.actual_members 1
+servers.hostname.mdstat.md0.status.blocks 102272
+servers.hostname.mdstat.md0.status.superblock_version 1.2
+servers.hostname.mdstat.md0.status.total_members 2
+```
+

--- a/docs/collectors/MdStatCollector.md
+++ b/docs/collectors/MdStatCollector.md
@@ -17,7 +17,6 @@ https://raid.wiki.kernel.org/index.php/Mdstat
 Setting | Default | Description | Type
 --------|---------|-------------|-----
 byte_unit | byte | Default numeric output(s) | str
-device_filter | ^md[0-9]*$ | A regex pattern.Metrics will be collected for any md device matching the pattern | str
 enabled | False | Enable collecting these metrics | bool
 measure_collector_time | False | Collect the collector run time in ms | bool
 metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
@@ -41,4 +40,3 @@ servers.hostname.mdstat.md0.status.blocks 102272
 servers.hostname.mdstat.md0.status.superblock_version 1.2
 servers.hostname.mdstat.md0.status.total_members 2
 ```
-

--- a/src/collectors/mdstat/mdstat.py
+++ b/src/collectors/mdstat/mdstat.py
@@ -95,19 +95,19 @@ class MdStatCollector(diamond.collector.Collector):
             # no md arrays found
             return arrays
         for block in mdstat_array_blocks.split('\n\n'):
-            md_device_name = self.parse_mdstat_device_name(block)
+            md_device_name = self.parse_device_name(block)
             if md_device_name:
                 # this block contains a whitelisted md device name
 
                 # 'member_count' and 'status' are mandatory keys
                 arrays[md_device_name] = {
                     'member_count': self.parse_array_member_state(block),
-                    'status': self.parse_mdstat_array_status(block),
+                    'status': self.parse_array_status(block),
                 }
 
                 # 'bitmap' and 'recovery' are optional keys
-                bitmap_status = self.parse_mdstat_array_bitmap(block)
-                recovery_status = self.parse_mdstat_array_recovery(block)
+                bitmap_status = self.parse_array_bitmap(block)
+                recovery_status = self.parse_array_recovery(block)
                 if bitmap_status:
                     arrays[md_device_name].update(
                         {'bitmap': bitmap_status}
@@ -119,14 +119,14 @@ class MdStatCollector(diamond.collector.Collector):
 
         return arrays
 
-    def parse_mdstat_device_name(self, block):
+    def parse_device_name(self, block):
         """
         Parse and match for a whitelisted md device name.
 
         >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
         >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
         >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
-        >>> print parse_mdstat_device_name(block)
+        >>> print parse_device_name(block)
         md0
 
         :return: matched device name or None
@@ -176,14 +176,14 @@ class MdStatCollector(diamond.collector.Collector):
 
         return ret
 
-    def parse_mdstat_array_status(self, block):
+    def parse_array_status(self, block):
         """
         Parses the status of the md array.
 
         >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
         >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
         >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
-        >>> print parse_mdstat_array_status(block)
+        >>> print parse_array_status(block)
         {
             'total_members': '2',
             'actual_members': '2',
@@ -230,14 +230,14 @@ class MdStatCollector(diamond.collector.Collector):
 
         return array_status_dict_sanitizied
 
-    def parse_mdstat_array_bitmap(self, block):
+    def parse_array_bitmap(self, block):
         """
         Parses the bitmap status of the md array.
 
         >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
         >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
         >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
-        >>> print parse_mdstat_array_bitmap(block)
+        >>> print parse_array_bitmap(block)
         {
             'total_pages': '1',
             'allocated_pages': '1',
@@ -279,7 +279,7 @@ class MdStatCollector(diamond.collector.Collector):
 
         return array_bitmap_dict
 
-    def parse_mdstat_array_recovery(self, block):
+    def parse_array_recovery(self, block):
         """
         Parses the recovery progress of the md array.
 
@@ -288,7 +288,7 @@ class MdStatCollector(diamond.collector.Collector):
         >>>         '      [===================>.]  recovery = 99.5% '
         >>>         '(102272/102272) finish=13.37min speed=102272K/sec\n'
         >>>         '\n'
-        >>> print parse_mdstat_array_recovery(block)
+        >>> print parse_array_recovery(block)
         {
             'percent': '99.5',
             'speed': 104726528,

--- a/src/collectors/mdstat/mdstat.py
+++ b/src/collectors/mdstat/mdstat.py
@@ -92,11 +92,11 @@ class MdStatCollector(diamond.collector.Collector):
                         precision=1
                     )
 
-        md_state = self.parse_mdstat()
+        md_state = self._parse_mdstat()
 
         traverse(md_state, '')
 
-    def parse_mdstat(self):
+    def _parse_mdstat(self):
         """
         Parse /proc/mdstat.
 
@@ -134,19 +134,19 @@ class MdStatCollector(diamond.collector.Collector):
             # no md arrays found
             return arrays
         for block in mdstat_array_blocks.split('\n\n'):
-            md_device_name = self.parse_device_name(block)
+            md_device_name = self._parse_device_name(block)
             if md_device_name:
                 # this block begins with a md device name
 
                 # 'member_count' and 'status' are mandatory keys
                 arrays[md_device_name] = {
-                    'member_count': self.parse_array_member_state(block),
-                    'status': self.parse_array_status(block),
+                    'member_count': self._parse_array_member_state(block),
+                    'status': self._parse_array_status(block),
                 }
 
                 # 'bitmap' and 'recovery' are optional keys
-                bitmap_status = self.parse_array_bitmap(block)
-                recovery_status = self.parse_array_recovery(block)
+                bitmap_status = self._parse_array_bitmap(block)
+                recovery_status = self._parse_array_recovery(block)
                 if bitmap_status:
                     arrays[md_device_name].update(
                         {'bitmap': bitmap_status}
@@ -158,14 +158,14 @@ class MdStatCollector(diamond.collector.Collector):
 
         return arrays
 
-    def parse_device_name(self, block):
+    def _parse_device_name(self, block):
         """
         Parse for a md device name.
 
         >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
         >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
         >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
-        >>> print parse_device_name(block)
+        >>> print _parse_device_name(block)
         md0
 
         :return: parsed device name
@@ -173,14 +173,14 @@ class MdStatCollector(diamond.collector.Collector):
         """
         return block.split('\n')[0].split(' : ')[0]
 
-    def parse_array_member_state(self, block):
+    def _parse_array_member_state(self, block):
         """
         Parse the state of the the md array members.
 
         >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
         >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
         >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
-        >>> print parse_array_member_state(block)
+        >>> print _parse_array_member_state(block)
         {
             'active': 2,
             'faulty': 0,
@@ -215,14 +215,14 @@ class MdStatCollector(diamond.collector.Collector):
 
         return ret
 
-    def parse_array_status(self, block):
+    def _parse_array_status(self, block):
         """
         Parse the status of the md array.
 
         >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
         >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
         >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
-        >>> print parse_array_status(block)
+        >>> print _parse_array_status(block)
         {
             'total_members': '2',
             'actual_members': '2',
@@ -267,14 +267,14 @@ class MdStatCollector(diamond.collector.Collector):
 
         return array_status_dict_sanitizied
 
-    def parse_array_bitmap(self, block):
+    def _parse_array_bitmap(self, block):
         """
         Parse the bitmap status of the md array.
 
         >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
         >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
         >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
-        >>> print parse_array_bitmap(block)
+        >>> print _parse_array_bitmap(block)
         {
             'total_pages': '1',
             'allocated_pages': '1',
@@ -316,7 +316,7 @@ class MdStatCollector(diamond.collector.Collector):
 
         return array_bitmap_dict
 
-    def parse_array_recovery(self, block):
+    def _parse_array_recovery(self, block):
         """
         Parse the recovery progress of the md array.
 
@@ -325,7 +325,7 @@ class MdStatCollector(diamond.collector.Collector):
         >>>         '      [===================>.]  recovery = 99.5% '
         >>>         '(102272/102272) finish=13.37min speed=102272K/sec\n'
         >>>         '\n'
-        >>> print parse_array_recovery(block)
+        >>> print _parse_array_recovery(block)
         {
             'percent': '99.5',
             'speed': 104726528,

--- a/src/collectors/mdstat/mdstat.py
+++ b/src/collectors/mdstat/mdstat.py
@@ -71,6 +71,9 @@ class MdStatCollector(diamond.collector.Collector):
         :rtype: dict
         """
 
+        arrays = {}
+        mdstat_array_blocks = ''
+
         try:
             with open(self.MDSTAT_PATH, 'r') as f:
                 lines = f.readlines()
@@ -81,9 +84,7 @@ class MdStatCollector(diamond.collector.Collector):
                     err=err
                 )
             )
-
-        arrays = {}
-        mdstat_array_blocks = ''
+            return arrays
 
         for line in lines[1:-1]:
             # remove first and last line

--- a/src/collectors/mdstat/mdstat.py
+++ b/src/collectors/mdstat/mdstat.py
@@ -1,0 +1,343 @@
+# coding=utf-8
+
+"""
+Collect linux RAID/md state by parsing /proc/mdstat.
+https://raid.wiki.kernel.org/index.php/Mdstat
+
+#### Dependencies
+
+ * /proc/mdstat
+
+"""
+
+import diamond.collector
+import re
+
+
+class MdStatCollector(diamond.collector.Collector):
+    MDSTAT_PATH = '/proc/mdstat'
+
+    def get_default_config_help(self):
+        config_help = super(MdStatCollector, self).get_default_config_help()
+        config_help.update({
+            'device_filter': 'A regex pattern.'
+                             'Metrics will be collected for any md device '
+                             'matching the pattern'
+        })
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings
+        """
+        config = super(MdStatCollector, self).get_default_config()
+        config.update({
+            'path': 'mdstat',
+            'device_filter': '^md[0-9]*$'
+        })
+        return config
+
+    def process_config(self):
+        super(MdStatCollector, self).process_config()
+        self.device_filter = self.config['device_filter']
+
+        try:
+            self.device_regexp = re.compile(self.device_filter)
+        except re.error as err:
+            device_filter_default = self.get_default_config['device_filter']
+            self.log.exception(
+                'Error parsing device_filter regexp "{device_filter}": {err}\n'
+                'Using default value regexp "{default_regexp}".'
+                .format(
+                    err=err,
+                    device_filter=self.device_filter,
+                    default_regexp=device_filter_default
+                )
+            )
+            self.device_regexp = re.compile(device_filter_default)
+
+    def collect(self):
+        """Publish all mdstat metrics."""
+        def traverse(d, metric_name=''):
+            for key, value in d.iteritems():
+                if isinstance(value, dict):
+                    if metric_name == '':
+                        metric_name_next = key
+                    else:
+                        metric_name_next = metric_name + '.' + key
+                    traverse(value, metric_name_next)
+                else:
+                    metric_name_finished = metric_name + '.' + key
+                    self.publish_gauge(
+                        name=metric_name_finished,
+                        value=value,
+                        precision=1
+                    )
+
+        md_state = self.parse_mdstat()
+
+        traverse(md_state, '')
+
+    def parse_mdstat(self):
+        """
+        Parse /proc/mdstat.
+
+        File format:
+        The first line is the "Personalities" line.
+        It won't get parsed since it contains only string metrics.
+        The second to second-last lines contain raid array information.
+        The last line contains the unused devices.
+        It won't get parsed since it contains only string metrics.
+
+        :return: Parsed information
+        :rtype: dict
+        """
+
+        try:
+            with open(self.MDSTAT_PATH, 'r') as f:
+                lines = f.readlines()
+        except IOError as err:
+            self.log.exception(
+                'Error opening {mdstat_path} for reading: {err}'.format(
+                    mdstat_path=self.MDSTAT_PATH,
+                    err=err
+                )
+            )
+
+        arrays = {}
+        mdstat_array_blocks = ''
+
+        for line in lines[1:-1]:
+            # remove first and last line
+            # reverse readlines() afterwards
+            mdstat_array_blocks += line
+
+        if mdstat_array_blocks == '':
+            # no md arrays found
+            return arrays
+        for block in mdstat_array_blocks.split('\n\n'):
+            md_device_name = self.parse_mdstat_device_name(block)
+            if md_device_name:
+                # this block contains a whitelisted md device name
+                arrays[md_device_name] = {
+                    'member_count': self.parse_array_member_state(block),
+                    'status': self.parse_mdstat_array_status(block),
+                    'bitmap': self.parse_mdstat_array_bitmap(block),
+                    'recovery': self.parse_mdstat_array_recovery(block)
+                }
+                if not arrays[md_device_name]['bitmap']:
+                    arrays[md_device_name].pop('bitmap')
+                if not arrays[md_device_name]['recovery']:
+                    arrays[md_device_name].pop('recovery')
+
+        return arrays
+
+    def parse_mdstat_device_name(self, block):
+        """
+        Parse and match for a whitelisted md device name.
+
+        >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
+        >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
+        >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
+        >>> print parse_mdstat_device_name(block)
+        md0
+
+        :return: matched device name or None
+        :rtype: string
+        """
+        device_name = block.split('\n')[0].split(' : ')[0]
+        if self.device_regexp.match(device_name):
+            return device_name
+        else:
+            return None
+
+    def parse_array_member_state(self, block):
+        """
+        Parses the state of the the md array members.
+
+        >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
+        >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
+        >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
+        >>> print parse_array_member_state(block)
+        {
+            'active': 2,
+            'faulty': 0,
+            'spare': 1
+        }
+
+        :return: dictionary of states with according count
+        :rtype: dict
+        """
+        devices = block.split('\n')[0].split(' : ')[1].split(' ')[2:]
+
+        device_regexp = re.compile(
+            '^(?P<device_name>.*)'
+            '\[(?P<role_number>\d*)\]'
+            '\(?(?P<device_state>[FS])?\)?$'
+        )
+
+        ret = {
+            'active': 0,
+            'faulty': 0,
+            'spare': 0
+        }
+        for device in devices:
+            device_dict = device_regexp.match(device).groupdict()
+
+            if device_dict['device_state'] == 'S':
+                ret['spare'] += 1
+            elif device_dict['device_state'] == 'F':
+                ret['faulty'] += 1
+            else:
+                ret['active'] += 1
+
+        return ret
+
+    def parse_mdstat_array_status(self, block):
+        """
+        Parses the status of the md array.
+
+        >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
+        >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
+        >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
+        >>> print parse_mdstat_array_status(block)
+        {
+            'total_members': '2',
+            'actual_members': '2',
+            'algorithm': None,
+            'superblock_version': '1.2',
+            'chunk_size': None,
+            'blocks': '100171776'
+        }
+
+        :return: dictionary of status information
+        :rtype: dict
+        """
+        array_status_regexp = re.compile(
+            '^ *(?P<blocks>\d*) blocks '
+            '(?:super (?P<superblock_version>\d\.\d) )?'
+            '(?:level (?P<raid_level>\d), '
+            '(?P<chunk_size>\d*)k chunk, '
+            'algorithm (?P<algorithm>\d) )?'
+            '(?:\[(?P<total_members>\d*)/(?P<actual_members>\d*)\])?'
+            '(?:(?P<rounding_factor>\d*)k rounding)?.*$'
+        )
+
+        array_status_dict = \
+            array_status_regexp.match(block.split('\n')[1]).groupdict()
+
+        array_status_dict_sanitizied = {}
+
+        # convert all non None values to float
+        for key, value in array_status_dict.iteritems():
+            if not value:
+                continue
+            if key == 'superblock_version':
+                array_status_dict_sanitizied[key] = float(value)
+            else:
+                array_status_dict_sanitizied[key] = int(value)
+
+        if 'chunk_size' in array_status_dict_sanitizied:
+            # convert chunk size from kBytes to Bytes
+            array_status_dict_sanitizied['chunk_size'] *= 1024
+
+        if 'rounding_factor' in array_status_dict_sanitizied:
+            # convert rounding_factor from kBytes to Bytes
+            array_status_dict_sanitizied['rounding_factor'] *= 1024
+
+        return array_status_dict_sanitizied
+
+    def parse_mdstat_array_bitmap(self, block):
+        """
+        Parses the bitmap status of the md array.
+
+        >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
+        >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
+        >>>         '      bitmap: 1/1 pages [4KB], 65536KB chunk\n\n'
+        >>> print parse_mdstat_array_bitmap(block)
+        {
+            'total_pages': '1',
+            'allocated_pages': '1',
+            'page_size': 4096,
+            'chunk_size': 67108864
+        }
+
+        :return: dictionary of status information
+        :rtype: dict
+        """
+        array_bitmap_regexp = re.compile(
+            '^ *bitmap: (?P<allocated_pages>[0-9]*)/'
+            '(?P<total_pages>[0-9]*) pages '
+            '\[(?P<page_size>[0-9]*)KB\], '
+            '(?P<chunk_size>[0-9]*)KB chunk.*$',
+            re.MULTILINE
+        )
+
+        regexp_res = array_bitmap_regexp.search(block)
+
+        if not regexp_res:
+            return None
+
+        array_bitmap_dict = regexp_res.groupdict()
+
+        array_bitmap_dict_sanitizied = {}
+
+        # convert all values to int
+        for key, value in array_bitmap_dict.iteritems():
+                if not value:
+                    continue
+                array_bitmap_dict_sanitizied[key] = int(value)
+
+        # scale page_size to bytes
+        array_bitmap_dict_sanitizied['page_size'] *= 1024
+
+        # scale chunk_size to bytes
+        array_bitmap_dict_sanitizied['chunk_size'] *= 1024
+
+        return array_bitmap_dict
+
+    def parse_mdstat_array_recovery(self, block):
+        """
+        Parses the recovery progress of the md array.
+
+        >>> block = 'md0 : active raid1 sdd2[0] sdb2[2](S) sdc2[1]\n'
+        >>>         '      100171776 blocks super 1.2 [2/2] [UU]\n'
+        >>>         '      [===================>.]  recovery = 99.5% '
+        >>>         '(102272/102272) finish=13.37min speed=102272K/sec\n'
+        >>>         '\n'
+        >>> print parse_mdstat_array_recovery(block)
+        {
+            'percent': '99.5',
+            'speed': 104726528,
+            'remaining_time': 802199
+        }
+
+        :return: dictionary of recovery progress information
+        :rtype: dict
+        """
+        array_recovery_regexp = re.compile(
+            '^ *\[.*\] *recovery = (?P<percent>\d*\.?\d*)%'
+            ' \(\d*/\d*\) finish=(?P<remaining_time>\d*\.?\d*)min '
+            'speed=(?P<speed>\d*)K/sec$',
+            re.MULTILINE
+        )
+
+        regexp_res = array_recovery_regexp.search(block)
+
+        if not regexp_res:
+            return None
+
+        array_recovery_dict = regexp_res.groupdict()
+
+        array_recovery_dict['percent'] = \
+            float(array_recovery_dict['percent'])
+
+        # scale speed to bits
+        array_recovery_dict['speed'] = \
+            int(array_recovery_dict['speed']) * 1024
+
+        # scale minutes to milliseconds
+        array_recovery_dict['remaining_time'] = \
+            int(float(array_recovery_dict['remaining_time'])*60*1000)
+
+        return array_recovery_dict

--- a/src/collectors/mdstat/mdstat.py
+++ b/src/collectors/mdstat/mdstat.py
@@ -19,11 +19,6 @@ class MdStatCollector(diamond.collector.Collector):
 
     def get_default_config_help(self):
         config_help = super(MdStatCollector, self).get_default_config_help()
-        config_help.update({
-            'device_filter': 'A regex pattern.'
-                             'Metrics will be collected for any md device '
-                             'matching the pattern'
-        })
         return config_help
 
     def get_default_config(self):
@@ -33,28 +28,11 @@ class MdStatCollector(diamond.collector.Collector):
         config = super(MdStatCollector, self).get_default_config()
         config.update({
             'path': 'mdstat',
-            'device_filter': '^md[0-9]*$'
         })
         return config
 
     def process_config(self):
         super(MdStatCollector, self).process_config()
-        self.device_filter = self.config['device_filter']
-
-        try:
-            self.device_regexp = re.compile(self.device_filter)
-        except re.error as err:
-            device_filter_default = self.get_default_config['device_filter']
-            self.log.exception(
-                'Error parsing device_filter regexp "{device_filter}": {err}\n'
-                'Using default value regexp "{default_regexp}".'
-                .format(
-                    err=err,
-                    device_filter=self.device_filter,
-                    default_regexp=device_filter_default
-                )
-            )
-            self.device_regexp = re.compile(device_filter_default)
 
     def collect(self):
         """Publish all mdstat metrics."""
@@ -145,11 +123,7 @@ class MdStatCollector(diamond.collector.Collector):
         :return: matched device name or None
         :rtype: string
         """
-        device_name = block.split('\n')[0].split(' : ')[0]
-        if self.device_regexp.match(device_name):
-            return device_name
-        else:
-            return None
+        return block.split('\n')[0].split(' : ')[0]
 
     def parse_array_member_state(self, block):
         """

--- a/src/collectors/mdstat/test/fixtures/mdstat_empty
+++ b/src/collectors/mdstat/test/fixtures/mdstat_empty
@@ -1,0 +1,2 @@
+Personalities :
+unused devices: <none>

--- a/src/collectors/mdstat/test/fixtures/mdstat_linear
+++ b/src/collectors/mdstat/test/fixtures/mdstat_linear
@@ -1,0 +1,5 @@
+Personalities : [raid1] [raid6] [raid5] [raid4] [linear]
+md0 : active linear sda1[1] sda2[0]
+      199800 blocks super 1.2 999k rounding
+
+unused devices: <none>

--- a/src/collectors/mdstat/test/fixtures/mdstat_multipath
+++ b/src/collectors/mdstat/test/fixtures/mdstat_multipath
@@ -1,0 +1,5 @@
+Personalities : [raid1] [raid6] [raid5] [raid4] [linear] [multipath]
+md0 : active multipath sda1[0] sda2[1]
+      102320 blocks super 1.2 [2/2] [UU]
+
+unused devices: <none>

--- a/src/collectors/mdstat/test/fixtures/mdstat_multiple
+++ b/src/collectors/mdstat/test/fixtures/mdstat_multiple
@@ -1,0 +1,11 @@
+Personalities : [raid6] [raid5] [raid4]
+md0 : active raid5 sda1[0] sda2[2] sda3[1]
+      39058432 blocks super 1.2 level 5, 512k chunk, algorithm 2 [3/3] [UUU]
+
+md1 : active linear sda1[1] sda2[0]
+      199800 blocks super 1.2 999k rounding
+
+md2 : active multipath sda1[0] sda2[1]
+      102320 blocks super 1.2 [2/2] [UU]
+
+unused devices: <none>

--- a/src/collectors/mdstat/test/fixtures/mdstat_raid1
+++ b/src/collectors/mdstat/test/fixtures/mdstat_raid1
@@ -1,0 +1,6 @@
+Personalities : [raid1]
+md0 : active raid1 sda1[1] sda2[0]
+      100171776 blocks super 1.2 [2/2] [UU]
+      bitmap: 1/1 pages [4KB], 65536KB chunk
+
+unused devices: <none>

--- a/src/collectors/mdstat/test/fixtures/mdstat_raid1-failed
+++ b/src/collectors/mdstat/test/fixtures/mdstat_raid1-failed
@@ -1,0 +1,5 @@
+Personalities : [raid1]
+md0 : active raid1 sda1[0] sda2[1](F)
+      102272 blocks super 1.2 [2/1] [U_]
+
+unused devices: <none>

--- a/src/collectors/mdstat/test/fixtures/mdstat_raid1-recover
+++ b/src/collectors/mdstat/test/fixtures/mdstat_raid1-recover
@@ -1,0 +1,7 @@
+Personalities : [raid1]
+md0 : active raid1 sda1[2] sda2[0]
+      102272 blocks super 1.2 [2/1] [U_]
+      bitmap: 1/1 pages [4KB], 65536KB chunk
+      [===================>.]  recovery = 99.5% (102272/102272) finish=13.37min speed=102272K/sec
+
+unused devices: <none>

--- a/src/collectors/mdstat/test/fixtures/mdstat_raid1-spare
+++ b/src/collectors/mdstat/test/fixtures/mdstat_raid1-spare
@@ -1,0 +1,6 @@
+Personalities : [raid1]
+md0 : active raid1 sda1[0] sda2[2](S) sda3[1]
+      100171776 blocks super 1.2 [2/2] [UU]
+      bitmap: 1/1 pages [4KB], 65536KB chunk
+
+unused devices: <none>

--- a/src/collectors/mdstat/test/fixtures/mdstat_raid5
+++ b/src/collectors/mdstat/test/fixtures/mdstat_raid5
@@ -1,0 +1,4 @@
+Personalities : [raid6] [raid5] [raid4]
+md0 : active raid5 sda1[0] sda2[2] sda3[1]
+      39058432 blocks super 1.2 level 5, 512k chunk, algorithm 2 [3/3] [UUU]
+unused devices: <none>

--- a/src/collectors/mdstat/test/test_mdstat.py
+++ b/src/collectors/mdstat/test/test_mdstat.py
@@ -81,9 +81,6 @@ class TestMdStatCollector(CollectorTestCase):
             'md1.member_count.spare': 0
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
@@ -100,9 +97,6 @@ class TestMdStatCollector(CollectorTestCase):
             'md0.member_count.spare': 0
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
@@ -120,9 +114,6 @@ class TestMdStatCollector(CollectorTestCase):
             'md0.member_count.spare': 0
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
@@ -144,9 +135,6 @@ class TestMdStatCollector(CollectorTestCase):
             'md0.bitmap.chunk_size': 65536
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
@@ -165,9 +153,6 @@ class TestMdStatCollector(CollectorTestCase):
             'md0.member_count.spare': 0
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
@@ -218,9 +203,6 @@ class TestMdStatCollector(CollectorTestCase):
             'md0.bitmap.chunk_size': 65536
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
@@ -242,9 +224,6 @@ class TestMdStatCollector(CollectorTestCase):
             'md0.member_count.spare': 0
         }
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
 if __name__ == "__main__":

--- a/src/collectors/mdstat/test/test_mdstat.py
+++ b/src/collectors/mdstat/test/test_mdstat.py
@@ -45,9 +45,6 @@ class TestMdStatCollector(CollectorTestCase):
 
         metrics = {}
 
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')

--- a/src/collectors/mdstat/test/test_mdstat.py
+++ b/src/collectors/mdstat/test/test_mdstat.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python2
+# coding=utf-8
+
+import os
+import io
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import patch
+
+from diamond.collector import Collector
+from mdstat import MdStatCollector
+
+
+class TestMdStatCollector(CollectorTestCase):
+
+    def setUp(self):
+        config = get_collector_config('MdStatCollector', {
+            'interval': 10
+        })
+
+        self.collector = MdStatCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(MdStatCollector)
+
+    @patch('__builtin__.open')
+    @patch('os.access', Mock(return_value=True))
+    @patch.object(Collector, 'publish')
+    def test_should_open_proc_loadavg(self, publish_mock, open_mock):
+        MdStatCollector.MDSTAT_PATH = '/proc/mdstat'
+        if not os.path.exists('/proc/mdstat'):
+            # on platforms that don't provide /proc/mdstat: don't bother
+            # testing this.
+            return
+        open_mock.return_value = io.BytesIO('')
+        self.collector.collect()
+        open_mock.assert_called_once_with('/proc/mdstat', 'r')
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_empty(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = self.getFixturePath('mdstat_empty')
+        self.collector.collect()
+
+        metrics = {}
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_multiple(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = self.getFixturePath('mdstat_multiple')
+        self.collector.collect()
+
+        metrics = {
+            'md2.status.superblock_version': 1.2,
+            'md2.status.actual_members': 2,
+            'md2.status.total_members': 2,
+            'md2.status.blocks': 102320,
+            'md2.member_count.active': 2,
+            'md2.member_count.faulty': 0,
+            'md2.member_count.spare': 0,
+            'md0.status.total_members': 3,
+            'md0.status.blocks': 39058432,
+            'md0.status.algorithm': 2,
+            'md0.status.superblock_version': 1.2,
+            'md0.status.raid_level': 5,
+            'md0.status.chunk_size': 524288,
+            'md0.status.actual_members': 3,
+            'md0.member_count.active': 3,
+            'md0.member_count.faulty': 0,
+            'md0.member_count.spare': 0,
+            'md1.status.superblock_version': 1.2,
+            'md1.status.blocks': 199800,
+            'md1.status.rounding_factor': 1022976,
+            'md1.member_count.active': 2,
+            'md1.member_count.faulty': 0,
+            'md1.member_count.spare': 0
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_linear(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = self.getFixturePath('mdstat_linear')
+        self.collector.collect()
+
+        metrics = {
+            'md0.status.superblock_version': 1.2,
+            'md0.status.blocks': 199800,
+            'md0.status.rounding_factor': 1022976,
+            'md0.member_count.active': 2,
+            'md0.member_count.faulty': 0,
+            'md0.member_count.spare': 0
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_multipath(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = self.getFixturePath('mdstat_multipath')
+        self.collector.collect()
+
+        metrics = {
+            'md0.status.superblock_version': 1.2,
+            'md0.status.actual_members': 2,
+            'md0.status.total_members': 2,
+            'md0.status.blocks': 102320,
+            'md0.member_count.active': 2,
+            'md0.member_count.faulty': 0,
+            'md0.member_count.spare': 0
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_raid1(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = self.getFixturePath('mdstat_raid1')
+        self.collector.collect()
+
+        metrics = {
+            'md0.status.superblock_version': 1.2,
+            'md0.status.actual_members': 2,
+            'md0.status.total_members': 2,
+            'md0.status.blocks': 100171776,
+            'md0.member_count.active': 2,
+            'md0.member_count.faulty': 0,
+            'md0.member_count.spare': 0,
+            'md0.bitmap.total_pages': 1,
+            'md0.bitmap.allocated_pages': 1,
+            'md0.bitmap.page_size': 4,
+            'md0.bitmap.chunk_size': 65536
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_raid1_failed(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = \
+            self.getFixturePath('mdstat_raid1-failed')
+        self.collector.collect()
+
+        metrics = {
+            'md0.status.superblock_version': 1.2,
+            'md0.status.actual_members': 1,
+            'md0.status.total_members': 2,
+            'md0.status.blocks': 102272,
+            'md0.member_count.active': 1,
+            'md0.member_count.faulty': 1,
+            'md0.member_count.spare': 0
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_raid1_recover(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = \
+            self.getFixturePath('mdstat_raid1-recover')
+        self.collector.collect()
+
+        metrics = {
+            'md0.status.superblock_version': 1.2,
+            'md0.status.actual_members': 1,
+            'md0.status.total_members': 2,
+            'md0.status.blocks': 102272,
+            'md0.recovery.percent': 99.5,
+            'md0.recovery.speed': 104726528,
+            'md0.recovery.remaining_time': 802199,
+            'md0.member_count.active': 2,
+            'md0.member_count.faulty': 0,
+            'md0.member_count.spare': 0,
+            'md0.bitmap.total_pages': 1,
+            'md0.bitmap.allocated_pages': 1,
+            'md0.bitmap.page_size': 4,
+            'md0.bitmap.chunk_size': 65536
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_raid1_spare(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = \
+            self.getFixturePath('mdstat_raid1-spare')
+        self.collector.collect()
+
+        metrics = {
+            'md0.status.superblock_version': 1.2,
+            'md0.status.actual_members': 2,
+            'md0.status.total_members': 2,
+            'md0.status.blocks': 100171776,
+            'md0.member_count.active': 2,
+            'md0.member_count.faulty': 0,
+            'md0.member_count.spare': 1,
+            'md0.bitmap.total_pages': 1,
+            'md0.bitmap.allocated_pages': 1,
+            'md0.bitmap.page_size': 4,
+            'md0.bitmap.chunk_size': 65536
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @patch.object(Collector, 'publish')
+    def test_mdstat_raid5(self, publish_mock):
+        MdStatCollector.MDSTAT_PATH = \
+            self.getFixturePath('mdstat_raid5')
+        self.collector.collect()
+
+        metrics = {
+            'md0.status.total_members': 3,
+            'md0.status.blocks': 39058432,
+            'md0.status.algorithm': 2,
+            'md0.status.superblock_version': 1.2,
+            'md0.status.raid_level': 5,
+            'md0.status.chunk_size': 524288,
+            'md0.status.actual_members': 3,
+            'md0.member_count.active': 3,
+            'md0.member_count.faulty': 0,
+            'md0.member_count.spare': 0
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a new collector for metric gathering of linux raid devices.  
It reads `/proc/mdstat` and has no other dependencies.  
I already tested it on production with `NullHandler` - :+1: works for me.

fixes #608 