### PR TITLE
Fix SmartCollector multiple value parsing

### DIFF
--- a/src/collectors/smart/test/fixtures/centos5.5_hdd
+++ b/src/collectors/smart/test/fixtures/centos5.5_hdd
@@ -22,3 +22,4 @@ ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_
 198 Offline_Uncorrectable   0x0030   200   200   000    Old_age   Offline      -       0
 199 UDMA_CRC_Error_Count    0x0032   200   200   000    Old_age   Always       -       0
 200 Multi_Zone_Error_Rate   0x0008   200   200   000    Old_age   Offline      -       0
+234 Thermal_Throttle        0x0032   100   100   000    Old_age   Always       -       0/0

--- a/src/collectors/smart/test/testsmart.py
+++ b/src/collectors/smart/test/testsmart.py
@@ -118,6 +118,8 @@ class TestSmartCollector(CollectorTestCase):
             'sda.Current_Pending_Sector': 0,
             'sda.Reallocated_Sector_Ct': 0,
             'sda.Seek_Error_Rate': 0,
+            'sda.Thermal_Throttle_0': 0,
+            'sda.Thermal_Throttle_1': 0,
         }
 
         self.setDocExample(collector=self.collector.__class__.__name__,


### PR DESCRIPTION
Values like 0/0 (used in Thermal_Throttle) caused collector to crash

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/diamond/utils/scheduler.py", line 73, in collector_process
    collector._run()
  File "/usr/local/lib/python2.7/dist-packages/diamond/collector.py", line 477, in _run
    self.collect()
  File "/usr/local/share/diamond/collectors/smart/smart.py", line 89, in collect
    self.publish(metric, metrics[metric])
  File "/usr/local/lib/python2.7/dist-packages/diamond/collector.py", line 397, in publish
    metric_type=metric_type, ttl=ttl)
  File "/usr/local/lib/python2.7/dist-packages/diamond/metric.py", line 62, in __init__
    "Metric %r: %s") % (path, e))
DiamondException: Invalid value when creating new Metric 'servers.**.smart.sdb.Thermal_Throttle': invalid literal for float(): 0/0
```

