### PR TITLE
Fixes the missing metrics from kafka.Controller:type=KafkaController

### DIFF
--- a/src/collectors/kafkastat/kafkastat.py
+++ b/src/collectors/kafkastat/kafkastat.py
@@ -122,12 +122,12 @@ class KafkaCollector(diamond.collector.Collector):
                     if "," in key_prefix:
                         key_prefix = key_prefix.split(',')[0]
                 elif i > 0:
-                    key = objectname.split('=')[i+1]
+                    key = objectname.split('=')[i + 1]
                     if key:
                         if '"' in key:
                             key = key.split('"')[1]
                         key_prefix = key_prefix + '.' + key
-                        key_prefix = key_prefix.replace(",",".")
+                        key_prefix = key_prefix.replace(",", ".")
 
         metrics = {}
 
@@ -141,7 +141,8 @@ class KafkaCollector(diamond.collector.Collector):
                 value = ptype(attrib.get('value'))
             except ValueError:
                 # It will be too busy, so not logging it every time
-                self.log.debug('Unable to parse the value for ' + atype + " in " + objectname)
+                self.log.debug('Unable to parse the value for ' +
+                               atype + " in " + objectname)
                 continue
             name = '.'.join([key_prefix, attrib.get('name')])
             # Some prefixes and attributes could have spaces, thus we must
@@ -172,10 +173,11 @@ class KafkaCollector(diamond.collector.Collector):
 
         # Query each one for stats
         for mbean in mbeans:
-            if mbean is None: continue
+            if mbean is None:
+                continue
             stats = self.query_mbean(mbean)
             if stats is None:
-                self.log.error('Failed to get stats for'+mbean)
+                self.log.error('Failed to get stats for' + mbean)
             metrics.update(stats)
 
         # Publish stats

--- a/src/collectors/kafkastat/kafkastat.py
+++ b/src/collectors/kafkastat/kafkastat.py
@@ -30,6 +30,7 @@ class KafkaCollector(diamond.collector.Collector):
         'double': float,
         'float': float,
         'int': int,
+        'java.lang.Object': float,
         'long': long,
     }
 
@@ -112,40 +113,36 @@ class KafkaCollector(diamond.collector.Collector):
             # java.lang:type=Threading
             # "kafka.controller":type="ControllerStats",
             # name="LeaderElectionRateAndTimeMs"
-            key_prefix = ''
-            for i, item in enumerate(objectname.split(',')):
+            split_num = objectname.count('=')
+            for i in range(split_num):
                 if i == 0:
-                    key_prefix = item.split('=')[1]
+                    key_prefix = objectname.split('=')[1]
                     if '"' in key_prefix:
                         key_prefix = key_prefix.split('"')[1]
                     if "," in key_prefix:
                         key_prefix = key_prefix.split(',')[0]
-                else:
-                    key = item.split('=')[1]
+                elif i > 0:
+                    key = objectname.split('=')[i+1]
                     if key:
                         if '"' in key:
                             key = key.split('"')[1]
-                        key_prefix = key_prefix + '.' + key.replace('.', '_')
+                        key_prefix = key_prefix + '.' + key
+                        key_prefix = key_prefix.replace(",",".")
 
         metrics = {}
+
         for attrib in attributes.getiterator(tag='Attribute'):
             atype = attrib.get('type')
+
             ptype = self.ATTRIBUTE_TYPES.get(atype)
-
-            if ptype is None:
-                for mbean_attrib in attributes.getiterator(tag='MBean'):
-                    if 'JmxReporter$Gauge' in mbean_attrib.get('classname'):
-                        ptype = float
-                        break
-
             if not ptype:
                 continue
-
             try:
                 value = ptype(attrib.get('value'))
-            except (TypeError, ValueError):
+            except ValueError:
+                # It will be too busy, so not logging it every time
+                self.log.debug('Unable to parse the value for ' + atype + " in " + objectname)
                 continue
-
             name = '.'.join([key_prefix, attrib.get('name')])
             # Some prefixes and attributes could have spaces, thus we must
             # sanitize them
@@ -175,7 +172,10 @@ class KafkaCollector(diamond.collector.Collector):
 
         # Query each one for stats
         for mbean in mbeans:
+            if mbean is None: continue
             stats = self.query_mbean(mbean)
+            if stats is None:
+                self.log.error('Failed to get stats for'+mbean)
             metrics.update(stats)
 
         # Publish stats

--- a/src/collectors/kafkastat/test/fixtures/activecontrollercount.xml
+++ b/src/collectors/kafkastat/test/fixtures/activecontrollercount.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MBean classname="com.yammer.metrics.reporting.JmxReporter$Gauge" description="Information on the management interface of the MBean" objectname="kafka.controller:type=KafkaController,name=ActiveControllerCount">
+   <Attribute availability="RO" description="Attribute exposed for management" isnull="false" name="Value" strinit="false" type="java.lang.Object" value="1" />
+   <Operation description="Operation exposed for management" impact="unknown" name="objectName" return="javax.management.ObjectName" />
+</MBean>

--- a/src/collectors/kafkastat/test/fixtures/kafkacontroller.xml
+++ b/src/collectors/kafkastat/test/fixtures/kafkacontroller.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Server>
+   <Domain name="kafka.controller">
+      <MBean classname="com.yammer.metrics.reporting.JmxReporter$Timer" description="Information on the management interface of the MBean" objectname="kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs" />
+      <MBean classname="com.yammer.metrics.reporting.JmxReporter$Meter" description="Information on the management interface of the MBean" objectname="kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec" />
+      <MBean classname="com.yammer.metrics.reporting.JmxReporter$Gauge" description="Information on the management interface of the MBean" objectname="kafka.controller:type=KafkaController,name=ActiveControllerCount" />
+      <MBean classname="com.yammer.metrics.reporting.JmxReporter$Gauge" description="Information on the management interface of the MBean" objectname="kafka.controller:type=KafkaController,name=OfflinePartitionsCount" />
+      <MBean classname="com.yammer.metrics.reporting.JmxReporter$Gauge" description="Information on the management interface of the MBean" objectname="kafka.controller:type=KafkaController,name=PreferredReplicaImbalanceCount" />
+   </Domain>
+</Server>

--- a/src/collectors/kafkastat/test/testkafka.py
+++ b/src/collectors/kafkastat/test/testkafka.py
@@ -27,7 +27,8 @@ def run_only_if_ElementTree_is_available(func):
     except ImportError:
         ElementTree = None
 
-    def pred(): return ElementTree is not None
+    def pred():
+        return ElementTree is not None
     return run_only(func, pred)
 
 

--- a/src/collectors/kafkastat/test/testkafka.py
+++ b/src/collectors/kafkastat/test/testkafka.py
@@ -136,6 +136,20 @@ class TestKafkaCollector(CollectorTestCase):
 
         self.assertEqual(metrics, expected_metrics)
 
+
+    @run_only_if_ElementTree_is_available
+    @patch.object(KafkaCollector, '_get')
+    def test_activeController_value(self, get_mock):
+        get_mock.return_value = self._get_xml_fixture('activecontrollercount.xml')
+
+        expected_metrics = {
+            'KafkaController.ActiveControllerCount.Value': 1.0,
+        }
+
+        metrics = self.collector.query_mbean('kafka.controller:type=KafkaController,name=ActiveControllerCount')
+
+        self.assertEqual(metrics, expected_metrics)
+
     @run_only_if_ElementTree_is_available
     @patch.object(KafkaCollector, '_get')
     def test_query_mbean_fail(self, get_mock):
@@ -154,6 +168,8 @@ class TestKafkaCollector(CollectorTestCase):
         if url_object.path == '/serverbydomain':
             if 'java.lang:type=GarbageCollector,name=*' in querynames:
                 return self.getFixture('serverbydomain_gc.xml')
+            elif '*kafka.controller:*' in querynames:
+                return self.getFixture('kafkacontroller.xml')
             elif 'java.lang:type=Threading' in querynames:
                 return self.getFixture('serverbydomain_threading.xml')
             else:
@@ -162,6 +178,9 @@ class TestKafkaCollector(CollectorTestCase):
             if ('java.lang:type=GarbageCollector,name=PS MarkSweep'
                     in objectnames):
                 return self.getFixture('gc_marksweep.xml')
+            elif ('kafka.controller:type=KafkaController,name=ActiveControllerCount'
+                  in objectnames):
+                return self.getFixture('activecontrollercount.xml')
             elif ('java.lang:type=GarbageCollector,name=PS Scavenge'
                   in objectnames):
                 return self.getFixture('gc_scavenge.xml')

--- a/src/collectors/kafkastat/test/testkafka.py
+++ b/src/collectors/kafkastat/test/testkafka.py
@@ -26,7 +26,8 @@ def run_only_if_ElementTree_is_available(func):
         from xml.etree import ElementTree
     except ImportError:
         ElementTree = None
-    pred = lambda: ElementTree is not None
+
+    def pred(): return ElementTree is not None
     return run_only(func, pred)
 
 
@@ -136,17 +137,18 @@ class TestKafkaCollector(CollectorTestCase):
 
         self.assertEqual(metrics, expected_metrics)
 
-
     @run_only_if_ElementTree_is_available
     @patch.object(KafkaCollector, '_get')
     def test_activeController_value(self, get_mock):
-        get_mock.return_value = self._get_xml_fixture('activecontrollercount.xml')
+        get_mock.return_value = self._get_xml_fixture(
+            'activecontrollercount.xml')
 
         expected_metrics = {
             'KafkaController.ActiveControllerCount.Value': 1.0,
         }
 
-        metrics = self.collector.query_mbean('kafka.controller:type=KafkaController,name=ActiveControllerCount')
+        metrics = self.collector.query_mbean(
+            'kafka.controller:type=KafkaController,name=ActiveControllerCount')
 
         self.assertEqual(metrics, expected_metrics)
 
@@ -178,7 +180,8 @@ class TestKafkaCollector(CollectorTestCase):
             if ('java.lang:type=GarbageCollector,name=PS MarkSweep'
                     in objectnames):
                 return self.getFixture('gc_marksweep.xml')
-            elif ('kafka.controller:type=KafkaController,name=ActiveControllerCount'
+            elif ('kafka.controller:type=KafkaController,' +
+                  'name=ActiveControllerCount'
                   in objectnames):
                 return self.getFixture('activecontrollercount.xml')
             elif ('java.lang:type=GarbageCollector,name=PS Scavenge'
@@ -217,6 +220,7 @@ class TestKafkaCollector(CollectorTestCase):
         }
 
         self.assertPublishedMany(publish_mock, expected_metrics)
+
 
 ###############################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
All the metrics under `kafka.Controller:type=KafkaController` were missing because Kafka reports the stats as `java.lang.Object`.These are critical metrics like OfflinePartitionCount and
ActiveControllerCount.

This patch also handles if the mbeans return empty or None for some reason. It will log for that particular objectName and move on. This will attempt to parse more objects than previous version but it's working okay for us. If it fails to find a numeric type, it will exit creating metrics. Since there was no fixture for this case I have added that too.