### PR TITLE
Update SignalFX Handler name + add filtering metrics

### DIFF
--- a/docs/handlers/SignalfxHandler.md
+++ b/docs/handlers/SignalfxHandler.md
@@ -14,11 +14,13 @@ Send metrics to signalfx
 #### Configuration
 Enable this handler
 
- * handers = diamond.handler.httpHandler.SignalfxHandler
+ * handlers = diamond.handler.signalfx.SignalfxHandler
 
  * auth_token = SIGNALFX_AUTH_TOKEN
  * batch_size = [optional | 300 ] will wait for this many requests before
      posting
+ * filter_metrics_regex = [optional] comma separated list of collector:regex
+     to limit metrics sent to signalfx,  default is to send everything
 
 #### Options
 
@@ -26,6 +28,7 @@ Setting | Default | Description | Type
 --------|---------|-------------|-----
 auth_token |  | Org API token to use when sending metrics | str
 batch | 300 | How many to store before sending | int
-get_default_config_help |  | get_default_config_help | 
+get_default_config_help |  | get_default_config_help |
 server_error_interval | 120 | How frequently to send repeated server errors | int
 url | https://ingest.signalfx.com/v2/datapoint | Where to send metrics | str
+filter_metrics_regex | | Comma Separated collector:regex filters| str

--- a/docs/handlers/SignalfxHandler.md
+++ b/docs/handlers/SignalfxHandler.md
@@ -28,7 +28,7 @@ Setting | Default | Description | Type
 --------|---------|-------------|-----
 auth_token |  | Org API token to use when sending metrics | str
 batch | 300 | How many to store before sending | int
+filter_metrics_regex | | Comma Separated collector:regex filters| str
 get_default_config_help |  | get_default_config_help |
 server_error_interval | 120 | How frequently to send repeated server errors | int
 url | https://ingest.signalfx.com/v2/datapoint | Where to send metrics | str
-filter_metrics_regex | | Comma Separated collector:regex filters| str

--- a/docs/handlers/SignalfxHandler.md
+++ b/docs/handlers/SignalfxHandler.md
@@ -21,6 +21,8 @@ Enable this handler
      posting
  * filter_metrics_regex = [optional] comma separated list of collector:regex
      to limit metrics sent to signalfx,  default is to send everything
+ * url = [optional | https://ingest.signalfx.com/v2/datapoint] where to send
+     metrics
 
 #### Options
 

--- a/src/diamond/handler/signalfx.py
+++ b/src/diamond/handler/signalfx.py
@@ -11,11 +11,12 @@ Send metrics to signalfx
 #### Configuration
 Enable this handler
 
- * handers = diamond.handler.httpHandler.SignalfxHandler
+ * handlers = diamond.handler.signalfx.SignalfxHandler
 
  * auth_token = SIGNALFX_AUTH_TOKEN
  * batch_size = [optional | 300 ] will wait for this many requests before
      posting
+ * filter_metrics_regex = [optional] comma separated list of collector_name:regex to limit metrics sent to signalfx, default is to send everything
 """
 
 from Handler import Handler
@@ -24,7 +25,7 @@ import json
 import logging
 import time
 import urllib2
-
+import re
 
 class SignalfxHandler(Handler):
 
@@ -32,14 +33,35 @@ class SignalfxHandler(Handler):
     def __init__(self, config=None):
         Handler.__init__(self, config)
         self.metrics = []
+        self.filter_metrics = self.config["filter_metrics_regex"]
         self.batch_size = int(self.config['batch'])
         self.url = self.config['url']
         self.auth_token = self.config['auth_token']
         self.batch_max_interval = self.config['batch_max_interval']
         self.resetBatchTimeout()
+        self._compiled_filters = []
+        for fltr in self.filter_metrics:
+            collector,metric = fltr.split(":")
+            self._compiled_filters.append((collector,
+                                           re.compile(metric),))
         if self.auth_token == "":
             logging.error("Failed to load Signalfx module")
             return
+
+
+
+    def _match_metric(self, metric):
+        """
+        matches the metric path, if the metrics are empty, it shorts to True
+        """
+        if len(self._compiled_filters) == 0:
+            return True
+        for (collector, filter_regex) in self._compiled_filters:
+            if collector != metric.getCollectorPath():
+                continue
+            if filter_regex.match(metric.getMetricPath()):
+                return True
+        return False
 
     def resetBatchTimeout(self):
         self.batch_max_timestamp = int(time.time() + self.batch_max_interval)
@@ -53,6 +75,7 @@ class SignalfxHandler(Handler):
         config.update({
             'url': 'Where to send metrics',
             'batch': 'How many to store before sending',
+            'filter_metrics_regex': 'Comma separated collector:regex to filter on',
             'auth_token': 'Org API token to use when sending metrics',
         })
 
@@ -67,8 +90,9 @@ class SignalfxHandler(Handler):
         config.update({
             'url': 'https://ingest.signalfx.com/v2/datapoint',
             'batch': 300,
-            # Don't wait more than 10 sec between pushes
-            'batch_max_interval': 10,
+            'filter_metrics_regex': '',
+            # Don't wait more than 30 sec between pushes
+            'batch_max_interval': 30,
             'auth_token': '',
         })
 
@@ -78,7 +102,8 @@ class SignalfxHandler(Handler):
         """
         Queue a metric.  Flushing queue if batch size reached
         """
-        self.metrics.append(metric)
+        if self._match_metric(metric):
+            self.metrics.append(metric)
         if self.should_flush():
             self._send()
 
@@ -134,6 +159,7 @@ class SignalfxHandler(Handler):
         self.resetBatchTimeout()
         try:
             urllib2.urlopen(req)
-        except urllib2.URLError:
-            logging.exception("Unable to post signalfx metrics")
+        except urllib2.URLError as err:
+            error_message = err.read()
+            logging.exception("Unable to post signalfx metrics"+  error_message)
             return

--- a/src/diamond/handler/signalfx.py
+++ b/src/diamond/handler/signalfx.py
@@ -16,7 +16,8 @@ Enable this handler
  * auth_token = SIGNALFX_AUTH_TOKEN
  * batch_size = [optional | 300 ] will wait for this many requests before
      posting
- * filter_metrics_regex = [optional] comma separated list of collector_name:regex to limit metrics sent to signalfx, default is to send everything
+ * filter_metrics_regex = [optional] comma separated list of collector:regex
+     to limit metrics sent to signalfx,  default is to send everything
 """
 
 from Handler import Handler
@@ -26,6 +27,7 @@ import logging
 import time
 import urllib2
 import re
+
 
 class SignalfxHandler(Handler):
 
@@ -41,14 +43,12 @@ class SignalfxHandler(Handler):
         self.resetBatchTimeout()
         self._compiled_filters = []
         for fltr in self.filter_metrics:
-            collector,metric = fltr.split(":")
+            collector, metric = fltr.split(":")
             self._compiled_filters.append((collector,
                                            re.compile(metric),))
         if self.auth_token == "":
             logging.error("Failed to load Signalfx module")
             return
-
-
 
     def _match_metric(self, metric):
         """
@@ -75,7 +75,7 @@ class SignalfxHandler(Handler):
         config.update({
             'url': 'Where to send metrics',
             'batch': 'How many to store before sending',
-            'filter_metrics_regex': 'Comma separated collector:regex to filter on',
+            'filter_metrics_regex': 'Comma separated collector:regex filters',
             'auth_token': 'Org API token to use when sending metrics',
         })
 
@@ -161,5 +161,5 @@ class SignalfxHandler(Handler):
             urllib2.urlopen(req)
         except urllib2.URLError as err:
             error_message = err.read()
-            logging.exception("Unable to post signalfx metrics"+  error_message)
+            logging.exception("Unable to post signalfx metrics" + error_message)
             return

--- a/src/diamond/handler/signalfx.py
+++ b/src/diamond/handler/signalfx.py
@@ -18,6 +18,8 @@ Enable this handler
      posting
  * filter_metrics_regex = [optional] comma separated list of collector:regex
      to limit metrics sent to signalfx,  default is to send everything
+ * url = [optional| https://ingest.signalfx.com/v2/datapoint] where to send
+     metrics
 """
 
 from Handler import Handler


### PR DESCRIPTION
This updates the SignalFX Handler to be able to provide a config
`filter_metrics_regex` that's in the form of comma separated list of
`collector_name:metrics_regex` that can be provided in the config
file.

if this regex isn't set, all metrics are sent, otherwise the metrics
will be filtered based on the list.