### PR TITLE
set precision of TCPCollector's metrics to 2

### DIFF
--- a/src/collectors/tcp/tcp.py
+++ b/src/collectors/tcp/tcp.py
@@ -272,6 +272,6 @@ class TCPCollector(diamond.collector.Collector):
 
             # Publish the metric
             if metric_name in self.config['gauges']:
-                self.publish_gauge(metric_name, value, 0)
+                self.publish_gauge(metric_name, value, 2)
             else:
-                self.publish_counter(metric_name, value, 0)
+                self.publish_counter(metric_name, value, 2)


### PR DESCRIPTION
Having precision=0 means that any non frequent metrics will be hidden by
diamond. For example: if interval=60 and a counter incremented once a minute
we have following math done by derivate():

old=1
new=2
derivative_x = 2-1 = 1
derivative_y = 60
result = 1 / 60 = 0.01666666666667

this value is later passed to Metric class which does following if
precision=0:

value = sprintf("%.0f", 0.01666666666667)

as result value becomes 0.