### PR TITLE
setup.py expects distro_major_version to be an int

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ else:
     ]
 
     distro = platform.dist()[0]
-    distro_major_version = platform.dist()[1].split('.')[0]
+    distro_major_version = int(platform.dist()[1].split('.')[0])
     if not distro:
         if 'amzn' in platform.uname()[2]:
             distro = 'centos'


### PR DESCRIPTION
Both systemd-unit-files and /etc/init.d/ scripts were being included on
RedHat-like 6 and 7 OSs RPM builds.