### PR TITLE
Ensure the timestamp passed to boto is UTC.

### DIFF
--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -228,7 +228,7 @@ class cloudwatchHandler(Handler):
           Send metrics to CloudWatch for the given dimensions
         """
 
-        timestamp = datetime.datetime.fromtimestamp(metric.timestamp)
+        timestamp = datetime.datetime.utcfromtimestamp(metric.timestamp)
 
         self.log.debug(
             "CloudWatch: Attempting to publish metric: %s to %s "


### PR DESCRIPTION
This is #372 rebased against master.

Should ensure proper operation in any timezone.