### PR TITLE
use dict(Counter(x)+Counter(y)) to calc sum of dicts

### DIFF
--- a/docs/collectors/MesosCollector.md
+++ b/docs/collectors/MesosCollector.md
@@ -35,6 +35,17 @@ port | 5050 | Port (default is 5050; set to 5051 for mesos-agent) | int
 #### Example Output
 
 ```
-__EXAMPLESHERE__
+servers.hostname.mesos.failed_tasks 6
+servers.hostname.mesos.finished_tasks 1
+servers.hostname.mesos.frameworks.marathon-0_7_6.executors.com_domain_group_anotherApp.mem_mapped_file_bytes 45056
+servers.hostname.mesos.frameworks.marathon-0_7_6.executors.task_name.06247c78-b6a9-11e4-99f6-fa163ef210c0.cpus_limit (1.1, 1)
+servers.hostname.mesos.frameworks.marathon-0_7_6.executors.task_name.09b6f20c-b6a9-11e4-99f6-fa163ef210c0.cpus_limit (0.6, 1)
+servers.hostname.mesos.frameworks.marathon-0_7_6.executors.task_name.cpus_limit (1.7, 1)
+servers.hostname.mesos.frameworks.marathon-0_7_6.executors.task_name.instances_count (2, 0)
+servers.hostname.mesos.frameworks.marathon-0_7_6.executors.task_name.mem_percent (0.19, 2)
+servers.hostname.mesos.master.elected 1
+servers.hostname.mesos.registrar.state_store_ms.p9999 (17.8412544, 6)
+servers.hostname.mesos.staged_tasks 20
+servers.hostname.mesos.system.mem_free_bytes 5663678464.1
 ```
 

--- a/src/collectors/mesos/mesos.py
+++ b/src/collectors/mesos/mesos.py
@@ -22,6 +22,7 @@ import diamond.collector
 import json
 import urllib2
 from urlparse import urlparse
+from collections import Counter
 
 import diamond.collector
 
@@ -169,12 +170,7 @@ class MesosCollector(diamond.collector.Collector):
         self._publish(r)
 
     def _sum_statistics(self, x, y):
-        stats = set(x) | set(y)
-        summed_stats = {
-            key: x.get(key, 0) + y.get(key, 0)
-            for key in stats
-        }
-        return summed_stats
+        return dict(Counter(x) + Counter(y))
 
     def _collect_slave_statistics(self):
         result = self._get('monitor/statistics')


### PR DESCRIPTION
fix syntax error on python 2.6

```
[2017-03-30 06:56:15,401] [MainThread] Failed to import module: mesos. Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/diamond/utils/classes.py", line 159, in load_collectors_from_paths
    mod = imp.load_module(modname, fp, pathname, description)
  File "/usr/share/diamond/collectors/mesos/mesos.py", line 175
    for key in stats
      ^
SyntaxError: invalid syntax
```