### PR TITLE
Allow aborting when the handlers process exit

### DIFF
--- a/conf/diamond.conf.example
+++ b/conf/diamond.conf.example
@@ -40,6 +40,8 @@ handlers_path = /usr/share/diamond/handlers/
 # When metric queue is full, new metrics are dropped.
 metric_queue_size = 16384
 
+# Abort the diamond process if the handler process exits
+abort_on_handlers_process_exit = False
 
 ################################################################################
 ### Options for handlers


### PR DESCRIPTION
The main diamond process takes care of the exited collectors but doesn't really take care of the exited handlers. This caused a problem for us where we weren't getting the stats. If the whole process had exited, the full diamond process could have got restarted by the svc daemon.
Hence, created an option to allow aborting when the handlers process exits and in that case it just exits.

Tested the option by manually killing the Handlers process and ensuring that the diamond process exits when the option is true and not otherwise. 