### PR TITLE
dict generator does not work for python 2.6

### DIFF
--- a/src/collectors/mesos/mesos.py
+++ b/src/collectors/mesos/mesos.py
@@ -170,10 +170,9 @@ class MesosCollector(diamond.collector.Collector):
 
     def _sum_statistics(self, x, y):
         stats = set(x) | set(y)
-        summed_stats = {
-            key: x.get(key, 0) + y.get(key, 0)
-            for key in stats
-        }
+        summed_stats = dict([(key, x.get(key, 0) + y.get(key, 0))
+                             for key in stats
+                            ])
         return summed_stats
 
     def _collect_slave_statistics(self):

--- a/src/collectors/mesos/mesos.py
+++ b/src/collectors/mesos/mesos.py
@@ -171,8 +171,7 @@ class MesosCollector(diamond.collector.Collector):
     def _sum_statistics(self, x, y):
         stats = set(x) | set(y)
         summed_stats = dict([(key, x.get(key, 0) + y.get(key, 0))
-                             for key in stats
-                            ])
+                             for key in stats])
         return summed_stats
 
     def _collect_slave_statistics(self):

--- a/src/collectors/mesos/test/testmesos.py
+++ b/src/collectors/mesos/test/testmesos.py
@@ -2,7 +2,6 @@
 # coding=utf-8
 ##########################################################################
 
-import json
 from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
@@ -166,10 +165,11 @@ class TestMesosCollector(CollectorTestCase):
                          self.collector._get_url("metrics/snapshot"))
 
     def test_sum_statistics(self):
-        results = json.load(self.getFixture('slave_monitor_statistics.json'))
-        sum = {}
-        for i in results:
-            sum = self.collector._sum_statistics(sum, i['statistics'])
+        metrics_1 = {'cpu': 50, 'mem': 30, 'loadavg': 1}
+        metrics_2 = {'cpu': 10, 'mem': 30, 'network': 10}
+        self.assertEqual(self.collector._sum_statistics(metrics_1, metrics_2),
+                         {'mem': 60, 'loadavg': 1, 'network': 10, 'cpu': 60})
+
 
 ##########################################################################
 if __name__ == "__main__":

--- a/src/collectors/mesos/test/testmesos.py
+++ b/src/collectors/mesos/test/testmesos.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 ##########################################################################
 
+import json
 from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
@@ -163,6 +164,12 @@ class TestMesosCollector(CollectorTestCase):
         self.collector.config['host'] = 'https://localhost'
         self.assertEqual('https://localhost:5050/metrics/snapshot',
                          self.collector._get_url("metrics/snapshot"))
+
+    def test_sum_statistics(self):
+        results = json.load(self.getFixture('slave_monitor_statistics.json'))
+        sum = {}
+        for i in results:
+            sum = self.collector._sum_statistics(sum, i['statistics'])
 
 ##########################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
duplicated with pull request #626

https://www.python.org/dev/peps/pep-0274/#semantics

```
The semantics of dict comprehensions can actually be demonstrated in stock Python 2.2, by passing a list comprehension to the built-in dictionary constructor:

>>> dict([(i, chr(65+i)) for i in range(4)])
is semantically equivalent to:

>>> {i : chr(65+i) for i in range(4)}
```