### PR TITLE
Fix handling of SIGINT on the main diamond process

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -12,7 +12,6 @@ import configobj
 import time
 import re
 import subprocess
-import signal
 
 from diamond.metric import Metric
 from diamond.utils.config import load_config
@@ -172,10 +171,6 @@ class Collector(object):
             self.name = self.__class__.__name__
         else:
             self.name = name
-
-        # Reset signal handlers of forks/threads
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
-        signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
         self.handlers = handlers
         self.last_values = {}

--- a/src/diamond/utils/scheduler.py
+++ b/src/diamond/utils/scheduler.py
@@ -29,6 +29,10 @@ def collector_process(collector, metric_queue, log):
     signal.signal(signal.SIGHUP, signal_to_exception)
     signal.signal(signal.SIGUSR2, signal_to_exception)
 
+    # Reset signal handlers of forks/threads
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
     interval = float(collector.config['interval'])
 
     log.debug('Starting')


### PR DESCRIPTION
 https://github.com/python-diamond/Diamond/commit/7db25796a9c20d81749a76eacf910b371e6652bb caused the regression where the main diamond process stopped handling SIGINT as intended.

The diff want to stop signal handling for the collector processes but was doing it in the collector constructor. The constructor is not the right place to reset as it is really constructed in the main process. Because of this, the signal handler of the main process was getting reset and the signal handler of the main process wasn't really getting called. 

Deployed and tested that SIGINT on the main diamond process really kills all the child processes.