### PR TITLE
Add positional argument specifiers for statement

### DIFF
--- a/bin/diamond
+++ b/bin/diamond
@@ -304,7 +304,7 @@ def main():
                     # join() on each of them. This guarantees that the
                     # SyncManager is terminated last (implicitly as a result of
                     # us exiting).
-                    child_debug = "Terminating and joining on: {} ({})"
+                    child_debug = "Terminating and joining on: {0} ({1})"
                     log.debug(child_debug.format(child.name, child.pid))
                     child.terminate()
                     child.join()


### PR DESCRIPTION
By omitting the positional specifiers it pushes the Python requirement to 2.7+ (right now the docs state 2.4+).

See: https://docs.python.org/2/library/string.html#format-string-syntax
"Changed in version 2.7: The positional argument specifiers can be omitted, so '{} {}' is equivalent to '{0} {1}'."