### PR TITLE
Support python26 - os.initgroups()

### DIFF
--- a/bin/diamond
+++ b/bin/diamond
@@ -201,7 +201,14 @@ def main():
             try:
                 if gid != -1 and uid != -1:
                     # Manually set the groups since they aren't set by default
-                    os.initgroups(pwd.getpwuid(uid).pw_name, gid)
+
+                    # Python 2.7+
+                    if hasattr(os, 'initgroups'):
+                        os.initgroups(user, gid)
+                    # Python 2.6
+                    else:
+                        os.setgroups([e.gr_gid for e in grp.getgrall()
+                                      if user in e.gr_mem] + [gid])
 
                 if gid != -1 and os.getgid() != gid:
                     # Set GID


### PR DESCRIPTION
os.initgroups() is new in python27

see https://github.com/python-diamond/Diamond/issues/638