### PR TITLE
Update Installation.md

### DIFF
--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -4,7 +4,7 @@
 ### Core
 
 - CentOS or Ubuntu
-- Python 2.4+
+- Python 2.6+
 - python-configobj
 - python-setuptools
 - make


### PR DESCRIPTION
python24 does _not_ work eg on RHEL5

python26 appears to be fine together with my previous pull