### PR TITLE
Include xa-datasource statistics to app metrics

### DIFF
--- a/src/collectors/jbossapi/jbossapi.py
+++ b/src/collectors/jbossapi/jbossapi.py
@@ -208,6 +208,9 @@ class JbossApiCollector(diamond.collector.Collector):
             if op_type == 'app' and self.config['app_stats'] == 'True':
                 if output:
                     # Grab the pool stats for each Instance
+                    if 'xa-data-source' in output['result']:
+                        output['result']['data-source'].update(output['result']['xa-data-source'])
+
                     for instance in output['result']['data-source']:
                         datasource = output['result']['data-source'][instance]
                         for metric in datasource['statistics']['pool']:
@@ -374,7 +377,6 @@ class JbossApiCollector(diamond.collector.Collector):
         return tmp_result.group(1)
 
     def collect(self):
-
         for host in self.config['hosts']:
             matches = re.search(
                 '^([^:]*):([^@]*)@([^:]*):([^:]*):?(.*)', host)
@@ -387,7 +389,7 @@ class JbossApiCollector(diamond.collector.Collector):
             current_proto = matches.group(5)
             current_user = matches.group(1)
             current_pword = matches.group(2)
-
+            
             # Call get_stats for each instance of jboss
             self.get_stats(current_host, current_port, current_proto,
                            current_user, current_pword)


### PR DESCRIPTION
Current jbossapi collector fetch only data-sources skipping xa-data-sources, in this commit I included xa-data-sources for metrics