### PR TITLE
fix undefined var 'user'

### DIFF
--- a/bin/diamond
+++ b/bin/diamond
@@ -201,6 +201,7 @@ def main():
             try:
                 if gid != -1 and uid != -1:
                     # Manually set the groups since they aren't set by default
+                    user = pwd.getpwuid(uid).pw_name
 
                     # Python 2.7+
                     if hasattr(os, 'initgroups'):


### PR DESCRIPTION
when a user, group is defined in diamond.conf, we end up with the below error,

 ERROR: Failed to set UID/GID. global name 'user' is not defined

Seems to be introduced in [ad3862d76c](https://github.com/python-diamond/Diamond/commit/ad3862d76c583f9ec623758344165da11cef8c62 ),

This fixes it on nix based OS's, it  needs testing on 'nt' based systems since 'pwd' might not be available on those