### PR TITLE
correct execute permission checking in nagios collector

### DIFF
--- a/src/collectors/nagios/nagios.py
+++ b/src/collectors/nagios/nagios.py
@@ -71,12 +71,12 @@ class NagiosStatsCollector(diamond.collector.Collector):
     def collect(self):
         # Cannot access binary and not using sudo
         if (not os.access(self.config['bin'], os.X_OK) and
-             not str_to_bool(self.config['use_sudo'])):
+            not str_to_bool(self.config['use_sudo'])):
             return
 
         # Using sudo but cannot access it
         if (str_to_bool(self.config['use_sudo']) and
-              not os.access(self.config['sudo_cmd'], os.X_OK)):
+            not os.access(self.config['sudo_cmd'], os.X_OK)):
             return
 
         command = [self.config['bin'],

--- a/src/collectors/nagios/nagios.py
+++ b/src/collectors/nagios/nagios.py
@@ -69,9 +69,14 @@ class NagiosStatsCollector(diamond.collector.Collector):
         return config
 
     def collect(self):
-        if ((not os.access(self.config['bin'], os.X_OK) or
-             (str_to_bool(self.config['use_sudo']) and
-              not os.access(self.config['sudo_cmd'], os.X_OK)))):
+        # Cannot access binary and not using sudo
+        if (not os.access(self.config['bin'], os.X_OK) and
+             not str_to_bool(self.config['use_sudo'])):
+            return
+
+        # Using sudo but cannot access it
+        if (str_to_bool(self.config['use_sudo']) and
+              not os.access(self.config['sudo_cmd'], os.X_OK)):
             return
 
         command = [self.config['bin'],


### PR DESCRIPTION
The current boolean with cause the collect() to return when you enable sudo, but as the current user cannot access the nagiosstats binary. This seems incorrect because that is precisely the reason one would use sudo.