### PR TITLE
Allow setting a timestamp when publishing a metric

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -371,7 +371,7 @@ class Collector(object):
         raise NotImplementedError()
 
     def publish(self, name, value, raw_value=None, precision=0,
-                metric_type='GAUGE', instance=None):
+                metric_type='GAUGE', instance=None, timestamp=None):
         """
         Publish a metric with the given name
         """
@@ -392,7 +392,7 @@ class Collector(object):
 
         # Create Metric
         try:
-            metric = Metric(path, value, raw_value=raw_value, timestamp=None,
+            metric = Metric(path, value, raw_value=raw_value, timestamp=timestamp,
                             precision=precision, host=self.get_hostname(),
                             metric_type=metric_type, ttl=ttl)
         except DiamondException:

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -392,9 +392,10 @@ class Collector(object):
 
         # Create Metric
         try:
-            metric = Metric(path, value, raw_value=raw_value, timestamp=timestamp,
-                            precision=precision, host=self.get_hostname(),
-                            metric_type=metric_type, ttl=ttl)
+            metric = Metric(path, value, raw_value=raw_value,
+                            timestamp=timestamp, precision=precision,
+                            host=self.get_hostname(), metric_type=metric_type,
+                            ttl=ttl)
         except DiamondException:
             self.log.error(('Error when creating new Metric: path=%r, '
                             'value=%r'), path, value)


### PR DESCRIPTION
I have collectors that publish multiple metrics in one `process` run. Since it takes some time to get the data, I would like to set the timestamp when calling the `publish` function. This PR just adds the timestamp as a optional parameter to the `publish` function and forwards the value to the Metric class.