### PR TITLE
Use valid format for InfluxDBClient.write_points and convert metric path to metric name plus tags

### DIFF
--- a/src/diamond/handler/influxdbHandler.py
+++ b/src/diamond/handler/influxdbHandler.py
@@ -169,20 +169,17 @@ class InfluxdbHandler(Handler):
                 metrics = []
                 for path in self.batch:
                     pathlist = path.split(".")
-                    tags = {"hostname" : pathlist[1]}
+                    tags = {"hostname": pathlist[1]}
                     if len(pathlist) > 4 and pathlist[3].startswith("cpu"):
                         cpu = pathlist[3].replace("cpu", "")
-                        tags.update({"cpuid" : cpu})
+                        tags.update({"cpuid": cpu})
                     vlist = self.batch[path][0]
                     name = pathlist[-1]
                     if not name.startswith(pathlist[2]):
                         name = pathlist[2]+"_"+pathlist[-1]
-                    measurement ={
-                                    "time" : vlist[0],
-                                    "tags" : tags,
-                                    "measurement": name,
-                                    "fields": { "value" : float(vlist[1])}
-                                 }
+                    measurement = {"time": vlist[0], "tags": tags,
+                                   "measurement": name,
+                                   "fields": {"value": float(vlist[1])}}
                     metrics.append(measurement)
                 # Send data to influxdb
                 self.log.debug("InfluxdbHandler: writing %d series of data",

--- a/src/diamond/handler/influxdbHandler.py
+++ b/src/diamond/handler/influxdbHandler.py
@@ -135,8 +135,7 @@ class InfluxdbHandler(Handler):
                                                            metric.value])
             self.batch_count += 1
         # If there are sufficient metrics, then pickle and send
-        if self.batch_count >= self.batch_size and (
-                time.time() - self.batch_timestamp) > 2**self.time_multiplier:
+        if self.batch_count >= self.batch_size:
             # Log
             self.log.debug(
                 "InfluxdbHandler: Sending batch sizeof : %d/%d after %fs",
@@ -169,10 +168,22 @@ class InfluxdbHandler(Handler):
                 # build metrics data
                 metrics = []
                 for path in self.batch:
-                    metrics.append({
-                        "points": self.batch[path],
-                        "name": path,
-                        "columns": ["time", "value"]})
+                    pathlist = path.split(".")
+                    tags = {"hostname" : pathlist[1]}
+                    if len(pathlist) > 4 and pathlist[3].startswith("cpu"):
+                        cpu = pathlist[3].replace("cpu", "")
+                        tags.update({"cpuid" : cpu})
+                    vlist = self.batch[path][0]
+                    name = pathlist[-1]
+                    if not name.startswith(pathlist[2]):
+                        name = pathlist[2]+"_"+pathlist[-1]
+                    measurement ={
+                                    "time" : vlist[0],
+                                    "tags" : tags,
+                                    "measurement": name,
+                                    "fields": { "value" : float(vlist[1])}
+                                 }
+                    metrics.append(measurement)
                 # Send data to influxdb
                 self.log.debug("InfluxdbHandler: writing %d series of data",
                                len(metrics))


### PR DESCRIPTION
In my tests, the InfluxDB handler didn't work because the JSON dict created by the handler wasn't accepted by python-influxdb. I re-checked the implementation in python-influxdb and the problem is definitely on at the handler side.
This PR includes:
- Proper dict keys for python-influxdb
- Transform the metric path to metric name plus tags. This is probably not complete, currently only hostname and if available CPU are added to tags. The metric name will be <collector>_<name>
- Remove the timestamp test for sending a batch. This could cause a loss of metrics when the batch buffer is almost full and the handler should process a bunch of metrics coming in in a small time range.