### PR TITLE
CloudWatch custom dimensions and boto3

### DIFF
--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -89,7 +89,9 @@ class cloudwatchHandler(Handler):
         # Initialize Options
         self.region = self.config['region']
 
-        instance_metadata = boto.utils.get_instance_metadata()
+        instance_metadata = boto.utils.get_instance_metadata(
+            timeout=1, num_retries=5
+        )
         if 'instance-id' in instance_metadata:
             self.instance_id = instance_metadata['instance-id']
             self.log.debug("Setting InstanceId: " + self.instance_id)

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -36,6 +36,18 @@ metric = 05
 name = Avg05
 namespace = MachineLoad
 unit = None
+
+[[[SnmpUptime]]]
+collect_by_instance = False
+collect_without_dimension = True
+collector = snmpraw
+metric = sysUpTimeInstance
+name = Uptime
+namespace = Diamond
+unit = None
+[[[[additional_dimensions]]]]
+Hostname = foo
+
 """
 
 import sys
@@ -87,7 +99,8 @@ class cloudwatchHandler(Handler):
 
         self.valid_config = ('region', 'collector', 'metric', 'namespace',
                              'name', 'unit', 'collect_by_instance',
-                             'collect_without_dimension')
+                             'collect_without_dimension',
+                             'additional_dimensions')
 
         self.rules = []
         for key_name, section in self.config.items():
@@ -118,7 +131,8 @@ class cloudwatchHandler(Handler):
             'name': '',
             'unit': 'None',
             'collect_by_instance': True,
-            'collect_without_dimension': False
+            'collect_without_dimension': False,
+            'additional_dimensions': {}
         })
         return config
 
@@ -136,7 +150,9 @@ class cloudwatchHandler(Handler):
             'unit': 'CloudWatch metric unit',
             'collector': 'Diamond collector name',
             'collect_by_instance': 'Send metric with InstanceId dimension',
-            'collect_without_dimension': 'Send metric with no dimension'
+            'collect_without_dimension': 'Send metric with no dimension',
+            'additional_dimensions': 'Name/Value additional dimensions to '
+                                     'send with metric'
         })
 
         return config
@@ -155,7 +171,8 @@ class cloudwatchHandler(Handler):
             'name': 'Avg01',
             'unit': 'None',
             'collect_by_instance': True,
-            'collect_without_dimension': False
+            'collect_without_dimension': False,
+            'additional_dimensions': {}
         })
 
         return config
@@ -229,6 +246,8 @@ class cloudwatchHandler(Handler):
         """
 
         timestamp = datetime.datetime.utcfromtimestamp(metric.timestamp)
+
+        dimensions.update(rule['additional_dimensions'])
 
         self.log.debug(
             "CloudWatch: Attempting to publish metric: %s to %s "

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -45,7 +45,7 @@ metric = sysUpTimeInstance
 name = Uptime
 namespace = Diamond
 unit = None
-[[[[additional_dimensions]]]]
+[[[[collect_with_dimensions]]]]
 Hostname = foo
 
 """
@@ -102,7 +102,7 @@ class cloudwatchHandler(Handler):
         self.valid_config = ('region', 'collector', 'metric', 'namespace',
                              'name', 'unit', 'collect_by_instance',
                              'collect_without_dimension',
-                             'additional_dimensions')
+                             'collect_with_dimensions')
 
         self.rules = []
         for key_name, section in self.config.items():
@@ -134,7 +134,7 @@ class cloudwatchHandler(Handler):
             'unit': 'None',
             'collect_by_instance': True,
             'collect_without_dimension': False,
-            'additional_dimensions': {}
+            'collect_with_dimensions': {}
         })
         return config
 
@@ -153,8 +153,8 @@ class cloudwatchHandler(Handler):
             'collector': 'Diamond collector name',
             'collect_by_instance': 'Send metric with InstanceId dimension',
             'collect_without_dimension': 'Send metric with no dimension',
-            'additional_dimensions': 'Name/Value additional dimensions to '
-                                     'send with metric'
+            'collect_with_dimensions': 'Name/Value additional dimensions to '
+                                       'send metric with'
         })
 
         return config
@@ -174,7 +174,7 @@ class cloudwatchHandler(Handler):
             'unit': 'None',
             'collect_by_instance': True,
             'collect_without_dimension': False,
-            'additional_dimensions': {}
+            'collect_with_dimensions': {}
         })
 
         return config
@@ -242,14 +242,18 @@ class cloudwatchHandler(Handler):
                         metric,
                         {})
 
+                if len(rule['collect_with_dimensions']) > 0:
+                    self.send_metrics_to_cloudwatch(
+                        rule,
+                        metric,
+                        rule['collect_with_dimensions'])
+
     def send_metrics_to_cloudwatch(self, rule, metric, dimensions):
         """
           Send metrics to CloudWatch for the given dimensions
         """
 
         timestamp = datetime.datetime.utcfromtimestamp(metric.timestamp)
-
-        dimensions.update(rule['additional_dimensions'])
 
         self.log.debug(
             "CloudWatch: Attempting to publish metric: %s to %s "

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -135,8 +135,8 @@ class cloudwatchHandler(Handler):
             'name': 'CloudWatch metric name',
             'unit': 'CloudWatch metric unit',
             'collector': 'Diamond collector name',
-            'collect_by_instance': 'Collect metrics for instances separately',
-            'collect_without_dimension': 'Collect metrics without dimension'
+            'collect_by_instance': 'Send metric with InstanceId dimension',
+            'collect_without_dimension': 'Send metric with no dimension'
         })
 
         return config


### PR DESCRIPTION
This rolls up two improvements for the cloudwatch handler:

1. Fix #678, switch from the deprecated boto AWS library (which, in addition to being deprecated, also doesn't support retrieving AWS credentials from the Instance Metadata Service or ECS Task Metadata).
2. Add support for custom dimensions to send along with metrics, per-metric.