### PR TITLE
add support string metric values for haproxy

### DIFF
--- a/src/collectors/haproxy/haproxy.py
+++ b/src/collectors/haproxy/haproxy.py
@@ -161,10 +161,23 @@ class HAProxyCollector(diamond.collector.Collector):
             metric_name = '%s%s.%s' % (section_name, part_one, part_two)
 
             for index, metric_string in enumerate(row):
+                if index < 2:
+                    continue
+
+                metric_string_ok = False
                 try:
                     metric_value = float(metric_string)
                 except ValueError:
-                    continue
+                    if not metric_string:
+                        continue
+                    metric_string_ok = True
+                    metric_value = 1
+
+                if metric_string_ok:
+                    stat_name = '%s.%s.%s' % (metric_name, headings[index],
+                                              self._sanitize(metric_string))
+                else:
+                    stat_name = '%s.%s' % (metric_name, headings[index])
 
                 stat_name = '%s.%s' % (metric_name, headings[index])
                 self.publish(stat_name, metric_value, metric_type='GAUGE')


### PR DESCRIPTION
there are few haproxy metrics have non-numeric values and
they are just as useful as the numeric counterparts. string
metric values will be appended to the initial metric name
and value will be set to 1