### PR TITLE
Updates for SmartCollector and New DirStatsCollector

### DIFF
--- a/docs/collectors/DirStatsCollector.md
+++ b/docs/collectors/DirStatsCollector.md
@@ -1,0 +1,29 @@
+<!--This file was generated from the python source
+Please edit the source to make changes
+-->
+DirStatsCollector
+=====
+
+Collect given directories stats.
+
+
+#### Options
+
+Setting | Default | Description | Type
+--------|---------|-------------|-----
+byte_unit | byte | Default numeric output(s) | str
+dirs | {} | directories to collect stats on | dict
+enabled | False | Enable collecting these metrics | bool
+measure_collector_time | False | Collect the collector run time in ms | bool
+metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
+metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
+
+#### Example Output
+
+```
+servers.hostname.dirstats.logs.size.current 9
+servers.hostname.dirstats.logs.size.allocated 18
+servers.hostname.dirstats.logs.days_unmodified 7
+servers.hostname.dirstats.logs.subdirs 5
+servers.hostname.dirstats.logs.files 18
+```

--- a/docs/collectors/SmartCollector.md
+++ b/docs/collectors/SmartCollector.md
@@ -8,42 +8,44 @@ Collect data from S.M.A.R.T.'s attribute reporting.
 
 #### Dependencies
 
- * [smartmontools](http://sourceforge.net/apps/trac/smartmontools/wiki)
+ * [smartmontools](https://www.smartmontools.org)
 
 
 #### Options
 
 Setting | Default | Description | Type
 --------|---------|-------------|-----
+aliases | {} | Aliases to assign | dict
+attributes | {} | Attributes to publish | dict
 bin | smartctl | The path to the smartctl binary | str
 byte_unit | byte | Default numeric output(s) | str
-devices | ^disk[0-9]$|^sd[a-z]$|^hd[a-z]$ | device regex to collect stats on | str
+devices | ^disk[0-9]$|^sd[a-z]$|^hd[a-z]$ | Devices to collect stats on (regexp) | str
 enabled | False | Enable collecting these metrics | bool
+force_prefails | False | If True, fetches all attributes with pre-fail priority and "attributes" specified in config. Otherwise, only "attributes" will be fetched. | bool
 measure_collector_time | False | Collect the collector run time in ms | bool
 metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
 metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
 sudo_cmd | /usr/bin/sudo | Path to sudo | str
 use_sudo | False | Use sudo? | bool
+valtypes | value, worst, thresh, raw_val, | Values to publish | list
 
 #### Example Output
 
 ```
-servers.hostname.smart.sda.Calibration_Retry_Count 0
-servers.hostname.smart.sda.Current_Pending_Sector 0
-servers.hostname.smart.sda.Load_Cycle_Count 2
-servers.hostname.smart.sda.Multi_Zone_Error_Rate 0
-servers.hostname.smart.sda.Offline_Uncorrectable 0
-servers.hostname.smart.sda.Power-Off_Retract_Count 5
-servers.hostname.smart.sda.Power_Cycle_Count 7
-servers.hostname.smart.sda.Power_On_Hours 6827
-servers.hostname.smart.sda.Raw_Read_Error_Rate 0
-servers.hostname.smart.sda.Reallocated_Event_Count 0
-servers.hostname.smart.sda.Reallocated_Sector_Ct 0
-servers.hostname.smart.sda.Seek_Error_Rate 0
-servers.hostname.smart.sda.Spin_Retry_Count 0
-servers.hostname.smart.sda.Spin_Up_Time 3991
-servers.hostname.smart.sda.Start_Stop_Count 8
-servers.hostname.smart.sda.Temperature_Celsius 28
-servers.hostname.smart.sda.UDMA_CRC_Error_Count 0
+servers.hostname.smart.sda.pre-fail.raw_read_error_rate.value 100
+servers.hostname.smart.sda.pre-fail.raw_read_error_rate.worst 100
+servers.hostname.smart.sda.pre-fail.raw_read_error_rate.thresh 16
+servers.hostname.smart.sda.pre-fail.raw_read_error_rate.raw_val  0
+servers.hostname.smart.sda.pre-fail.throughput_performance.value 138
+servers.hostname.smart.sda.pre-fail.throughput_performance.worst 138
+servers.hostname.smart.sda.pre-fail.throughput_performance.thresh 54
+servers.hostname.smart.sda.pre-fail.throughput_performance.raw_val 100
+servers.hostname.smart.sda.old-age.start_stop_count.value 100
+servers.hostname.smart.sda.old-age.start_stop_count.worst 100
+servers.hostname.smart.sda.old-age.start_stop_count.thresh 0
+servers.hostname.smart.sda.old-age.start_stop_count.raw_val 11
+servers.hostname.smart.sda.pre-fail.some_attribute.value 153
+servers.hostname.smart.sda.pre-fail.some_attribute.worst 153
+servers.hostname.smart.sda.pre-fail.some_attribute.thresh 24
+servers.hostname.smart.sda.pre-fail.some_attribute.raw_val 396
 ```
-

--- a/src/collectors/dirstats/dirstats.py
+++ b/src/collectors/dirstats/dirstats.py
@@ -1,0 +1,141 @@
+# coding=utf-8
+
+"""
+Collect given directories stats.
+
+"""
+
+import os
+
+from stat import S_ISDIR, S_ISREG
+from time import time
+
+try:
+    import Queue as queue
+except ImportError:
+    import queue
+
+import diamond.collector
+
+BLOCK = 512
+DAY = 86400
+MB = 1048576
+
+
+class Directory(object):
+    """
+    Directory object.
+    """
+    def __init__(self, path):
+
+        self.path = path
+        self.allocated = 0
+        self.size = 0
+        self.subdirs = 0
+        self.files = 0
+        self.modified = 0
+        self.skipped = set()
+
+    def _log_skipped(self, os_error):
+        """
+        Log skipped path.
+        """
+        self.skipped.add(
+            'Dirstats: skipping ' + os_error.filename + \
+            ' Reason: ' + os_error.strerror)
+
+    def get_stats(self):
+        """
+        Calculate directory size and number of days since last update.
+        """
+        dirs_queue = queue.Queue()
+        dirs_queue.put(self.path)
+
+        while not dirs_queue.empty():
+
+            try:
+
+                path = dirs_queue.get()
+                entities = os.listdir(path)
+
+            except OSError as os_error:
+                self._log_skipped(os_error)
+                continue
+
+            for entity in entities:
+                fullpath = os.path.join(path, entity)
+
+                try:
+
+                    mode = os.stat(fullpath).st_mode
+
+                    if S_ISDIR(mode):
+
+                        self.subdirs += 1
+                        dirs_queue.put(fullpath)
+
+                    elif S_ISREG(mode):
+
+                        self.files += 1
+                        self.size += os.stat(fullpath).st_blocks * BLOCK
+                        self.allocated += os.stat(fullpath).st_size
+                        last_modified = os.stat(fullpath).st_mtime
+                        if last_modified > self.modified:
+                            self.modified = last_modified
+
+                except OSError as os_error:
+                    self._log_skipped(os_error)
+                    continue
+
+        if not self.skipped and not self.modified:
+            self.modified = os.stat(self.path).st_mtime
+
+
+class DirStatsCollector(diamond.collector.Collector):
+
+    def get_default_config_help(self):
+        """
+        Returns the help text for the configuration options for this collector.
+        """
+        config_help = super(DirStatsCollector, self).get_default_config_help()
+        config_help.update({
+            'dirs': 'directories to collect stats on'})
+
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns default configuration options.
+        """
+        config = super(DirStatsCollector, self).get_default_config()
+        config.update({
+            'path': 'dirstats',
+            'dirs': {}})
+
+        return config
+
+    def collect(self):
+        """
+        Collect and publish directories stats.
+        """
+        metrics = {}
+
+        for dir_name in self.config['dirs']:
+
+            directory = Directory(self.config['dirs'][dir_name])
+            directory.get_stats()
+
+            if directory.skipped:
+                for message in directory.skipped:
+                    self.log.error(message)
+
+            metrics.update({
+                dir_name + '.size.allocated': int(directory.allocated/MB),
+                dir_name + '.size.current': int(directory.size/MB),
+                dir_name + '.subdirs': directory.subdirs,
+                dir_name + '.files': directory.files,
+                dir_name + '.days_unmodified': int(
+                    (time()-directory.modified)/DAY)})
+
+        for metric in metrics:
+            self.publish(metric, metrics[metric])

--- a/src/collectors/dirstats/dirstats.py
+++ b/src/collectors/dirstats/dirstats.py
@@ -41,7 +41,7 @@ class Directory(object):
         Log skipped path.
         """
         self.skipped.add(
-            'Dirstats: skipping ' + os_error.filename + \
+            'Dirstats: skipping ' + os_error.filename +
             ' Reason: ' + os_error.strerror)
 
     def get_stats(self):

--- a/src/collectors/dirstats/test/testdirstats.py
+++ b/src/collectors/dirstats/test/testdirstats.py
@@ -1,0 +1,158 @@
+#!/usr/bin/python
+# coding=utf-8
+##########################################################################
+
+from stat import S_IFDIR, S_IFREG
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+
+from time import time
+
+from mock import Mock
+from mock import patch
+
+from diamond.collector import Collector
+from dirstats import DirStatsCollector, DAY, MB
+
+##########################################################################
+
+
+class EntityMock(object):
+
+    def __init__(self, is_file):
+
+        if is_file:
+
+            self.st_mode = S_IFREG
+            self.st_size = MB
+            self.st_mtime = time()-(DAY*7)
+            self.st_blocks = 1024
+
+        else:
+
+            self.st_mode = S_IFDIR
+            self.st_mtime = time()-(DAY*5)
+
+
+class TestDirStatsCollector(CollectorTestCase):
+
+    def setUp(self):
+        config = get_collector_config('DirStatsCollector', {
+            'interval': 10,
+            'dirs': {
+                'logs': '/var/log/'}
+            })
+
+        self.collector = DirStatsCollector(config, None)
+
+    def entity_side_effect(self, path):
+
+        if 'file' in path:
+            return EntityMock(is_file=True)
+
+        return EntityMock(is_file=False)
+
+    def test_import(self):
+        self.assertTrue(DirStatsCollector)
+
+    @patch.object(Collector, 'publish')
+    def test_non_empty_directory(self, publish_mock):
+        patch_listdir = patch('os.listdir', Mock(
+            side_effect=[
+
+                # root level
+                #
+                # /var/log/DIR_1
+                # /var/log/DIR_2
+                # /var/log/DIR_3
+                # /var/log/file_1
+                # /var/log/file_2
+
+                ['DIR_1', 'DIR_2', 'DIR_3', 'file_1', 'file_2'],
+
+                # dir1 level
+                #
+                # /var/log/DIR_1/DIR_4
+                # /var/log/DIR_1/file_3
+                # /var/log/DIR_1/file_4
+                # /var/log/DIR_1/file_5
+                # /var/log/DIR_1/file_6
+
+                ['DIR_4', 'file_3', 'file_4', 'file_5', 'file_6'],
+
+                # dir2 level
+                #
+                # /var/log/DIR_2/file_7
+                # /var/log/DIR_2/file_8
+                # /var/log/DIR_2/DIR_5
+                # /var/log/DIR_2/file_9
+                # /var/log/DIR_2/file_10
+
+                ['file_7', 'file_8', 'DIR_5', 'file_9', 'file_10'],
+
+                # dir3 is empty, dir1/dir4 level
+                #
+                # /var/log/DIR_1/DIR_4/file_11
+                # /var/log/DIR_1/DIR_4/file_12
+                # /var/log/DIR_1/DIR_4/file_13
+                # /var/log/DIR_1/DIR_4/file_14
+
+                [], ['file_11', 'file_12', 'file_13', 'file_14'],
+
+                # dir2/dir5 level
+                #
+                # /var/log/DIR_2/DIR_5/file_15
+                # /var/log/DIR_2/DIR_5/file_16
+                # /var/log/DIR_2/DIR_5/file_17
+                # /var/log/DIR_2/DIR_5/file_18
+
+                ['file_15', 'file_16', 'file_17', 'file_18']]
+
+            ))
+
+        patch_stat = patch('os.stat', Mock(
+            side_effect=self.entity_side_effect
+            ))
+
+        patch_listdir.start()
+        patch_stat.start()
+        self.collector.collect()
+        patch_listdir.stop()
+        patch_stat.stop()
+
+        self.assertPublishedMany(publish_mock, {
+            'logs.size.current': 9,
+            'logs.size.allocated': 18,
+            'logs.subdirs': 5,
+            'logs.files': 18,
+            'logs.days_unmodified': 7
+        })
+
+    @patch.object(Collector, 'publish')
+    def test_empty_directory(self, publish_mock):
+        patch_listdir = patch('os.listdir', Mock(return_value=[]))
+
+        patch_stat = patch('os.stat', Mock(
+            side_effect=self.entity_side_effect
+            ))
+
+        patch_listdir.start()
+        patch_stat.start()
+        self.collector.collect()
+        patch_listdir.stop()
+        patch_stat.stop()
+
+        self.assertPublishedMany(publish_mock, {
+            'logs.size.current': 0,
+            'logs.size.allocated': 0,
+            'logs.subdirs': 0,
+            'logs.files': 0,
+            'logs.days_unmodified': 5
+        })
+
+
+##########################################################################
+if __name__ == "__main__":
+    unittest.main()

--- a/src/collectors/smart/smart.py
+++ b/src/collectors/smart/smart.py
@@ -84,8 +84,8 @@ class SmartCollector(diamond.collector.Collector):
             'attributes': 'Attributes to publish',
             'aliases': 'Aliases to assign',
             'valtypes': 'Values to publish',
-            'force_prefails': 'If True, fetches all attributes ' \
-            'with pre-fail priority and "attributes" specified ' \
+            'force_prefails': 'If True, fetches all attributes '
+            'with pre-fail priority and "attributes" specified '
             'in config. Otherwise, only "attributes" will be fetched.'})
 
         return config_help

--- a/src/collectors/smart/test/testsmart.py
+++ b/src/collectors/smart/test/testsmart.py
@@ -21,6 +21,23 @@ class TestSmartCollector(CollectorTestCase):
         config = get_collector_config('SmartCollector', {
             'interval': 10,
             'bin': 'true',
+            'valtypes': ['value', 'worst', 'thresh', 'raw_val'],
+            'attributes': {
+                'spin_up_time': True,
+                'power_cycle_count': True,
+                'temperature_celsius': True,
+                'udma_crc_error_count': True,
+                '172': True,
+                '174': True,
+                '234': True},
+            'aliases': {
+                'disk0': {
+                    '172': 'some_attribute',
+                    '174': 'and_other_one',
+                    '234': 'and_another_one'},
+                'sda': {
+                    'udma_crc_error_count': 'udma_crc_errs'}},
+            'force_prefails': True
         })
 
         self.collector = SmartCollector(config, None)
@@ -61,27 +78,57 @@ class TestSmartCollector(CollectorTestCase):
         patch_communicate.stop()
 
         self.assertPublishedMany(publish_mock, {
-            'disk0.172': 0,
-            'disk0.Head_Amplitude': 100,
-            'disk0.Reallocated_Sector_Ct': 0,
-            'disk0.Temperature_Celsius': 128,
-            'disk0.174': 3,
-            'disk0.Reported_Uncorrect': 0,
-            'disk0.Raw_Read_Error_Rate': 5849487,
-            'disk0.Power_On_Hours': 199389561752279,
-            'disk0.Total_LBAs_Read': 17985,
-            'disk0.Power_Cycle_Count': 381,
-            'disk0.Hardware_ECC_Recovered': 5849487,
-            'disk0.171': 0,
-            'disk0.Soft_Read_Error_Rate': 5849487,
-            'disk0.234': 2447,
-            'disk0.Program_Fail_Cnt_Total': 0,
-            'disk0.Media_Wearout_Indicator': 4881,
-            'disk0.Erase_Fail_Count_Total': 0,
-            'disk0.Wear_Leveling_Count': 2,
-            'disk0.Reallocated_Event_Count': 0,
-            'disk0.Total_LBAs_Written': 2447,
-            'disk0.Soft_ECC_Correction': 5849487,
+
+            # attributes
+
+            'disk0.old_age.power_cycle_count.value': 100,
+            'disk0.old_age.power_cycle_count.worst': 100,
+            'disk0.old_age.power_cycle_count.thresh': 0,
+            'disk0.old_age.power_cycle_count.raw_val': 381,
+
+            'disk0.pre-fail.temperature_celsius.value': 100,
+            'disk0.pre-fail.temperature_celsius.worst': 100,
+            'disk0.pre-fail.temperature_celsius.thresh': 10,
+            'disk0.pre-fail.temperature_celsius.raw_val': 0,
+
+            # value {force_prefails}
+
+            'disk0.pre-fail.head_amplitude.value': 100,
+            'disk0.pre-fail.reallocated_sector_ct.value': 100,
+            'disk0.pre-fail.raw_read_error_rate.value': 92,
+
+            # worst {force_prefails}
+
+            'disk0.pre-fail.head_amplitude.worst': 100,
+            'disk0.pre-fail.reallocated_sector_ct.worst': 100,
+            'disk0.pre-fail.raw_read_error_rate.worst': 92,
+
+            # thresh {force_prefails}
+
+            'disk0.pre-fail.head_amplitude.thresh': 000,
+            'disk0.pre-fail.reallocated_sector_ct.thresh': 3,
+            'disk0.pre-fail.raw_read_error_rate.thresh': 50,
+
+            # raw_val {force_prefails}
+
+            'disk0.pre-fail.head_amplitude.raw_val': 100,
+            'disk0.pre-fail.reallocated_sector_ct.raw_val': 0,
+            'disk0.pre-fail.raw_read_error_rate.raw_val': 5849487,
+
+            # aliases
+
+            'disk0.old_age.some_attribute.value': 0,
+            'disk0.old_age.and_other_one.value': 0,
+            'disk0.old_age.and_another_one.value': 0,
+            'disk0.old_age.some_attribute.worst': 0,
+            'disk0.old_age.and_other_one.worst': 0,
+            'disk0.old_age.and_another_one.worst': 0,
+            'disk0.old_age.some_attribute.thresh': 0,
+            'disk0.old_age.and_other_one.thresh': 0,
+            'disk0.old_age.and_another_one.thresh': 0,
+            'disk0.old_age.some_attribute.raw_val': 0,
+            'disk0.old_age.and_other_one.raw_val': 3,
+            'disk0.old_age.and_another_one.raw_val': 2447
         })
 
     @patch('os.access', Mock(return_value=True))
@@ -101,25 +148,50 @@ class TestSmartCollector(CollectorTestCase):
         patch_communicate.stop()
 
         metrics = {
-            'sda.Temperature_Celsius': 28,
-            'sda.Power_On_Hours': 6827,
-            'sda.Power_Cycle_Count': 7,
-            'sda.Power-Off_Retract_Count': 5,
-            'sda.UDMA_CRC_Error_Count': 0,
-            'sda.Load_Cycle_Count': 2,
-            'sda.Calibration_Retry_Count': 0,
-            'sda.Spin_Up_Time': 3991,
-            'sda.Spin_Retry_Count': 0,
-            'sda.Multi_Zone_Error_Rate': 0,
-            'sda.Raw_Read_Error_Rate': 0,
-            'sda.Reallocated_Event_Count': 0,
-            'sda.Start_Stop_Count': 8,
-            'sda.Offline_Uncorrectable': 0,
-            'sda.Current_Pending_Sector': 0,
-            'sda.Reallocated_Sector_Ct': 0,
-            'sda.Seek_Error_Rate': 0,
-            'sda.Thermal_Throttle_0': 0,
-            'sda.Thermal_Throttle_1': 0,
+
+            # attributes
+
+            'sda.pre-fail.spin_up_time.value': 140,
+            'sda.pre-fail.spin_up_time.worst': 140,
+            'sda.pre-fail.spin_up_time.thresh': 21,
+            'sda.pre-fail.spin_up_time.raw_val': 3991,
+
+            'sda.old_age.power_cycle_count.value': 100,
+            'sda.old_age.power_cycle_count.worst': 100,
+            'sda.old_age.power_cycle_count.thresh': 0,
+            'sda.old_age.power_cycle_count.raw_val': 7,
+
+            'sda.old_age.temperature_celsius.value': 115,
+            'sda.old_age.temperature_celsius.worst': 110,
+            'sda.old_age.temperature_celsius.thresh': 0,
+            'sda.old_age.temperature_celsius.raw_val': 28,
+
+            # value {force_prefails}
+
+            'sda.pre-fail.raw_read_error_rate.value': 200,
+            'sda.pre-fail.reallocated_sector_ct.value': 200,
+
+            # worst {force_prefails}
+
+            'sda.pre-fail.raw_read_error_rate.worst': 200,
+            'sda.pre-fail.reallocated_sector_ct.worst': 200,
+
+            # thresh {force_prefails}
+
+            'sda.pre-fail.raw_read_error_rate.thresh': 51,
+            'sda.pre-fail.reallocated_sector_ct.thresh': 140,
+
+            # raw_val {force_prefails}
+
+            'sda.pre-fail.raw_read_error_rate.raw_val': 0,
+            'sda.pre-fail.reallocated_sector_ct.raw_val': 0,
+
+            # aliases
+
+            'sda.old_age.udma_crc_errs.value': 200,
+            'sda.old_age.udma_crc_errs.worst': 200,
+            'sda.old_age.udma_crc_errs.thresh': 0,
+            'sda.old_age.udma_crc_errs.raw_val': 0
         }
 
         self.setDocExample(collector=self.collector.__class__.__name__,
@@ -144,23 +216,50 @@ class TestSmartCollector(CollectorTestCase):
         patch_communicate.stop()
 
         metrics = {
-            'sda.Raw_Read_Error_Rate': 0,
-            'sda.Spin_Up_Time': 4225,
-            'sda.Start_Stop_Count': 13,
-            'sda.Reallocated_Sector_Ct': 0,
-            'sda.Seek_Error_Rate': 0,
-            'sda.Power_On_Hours': 88,
-            'sda.Spin_Retry_Count': 0,
-            'sda.Calibration_Retry_Count': 0,
-            'sda.Power_Cycle_Count': 13,
-            'sda.Power-Off_Retract_Count': 7,
-            'sda.Load_Cycle_Count': 5,
-            'sda.Temperature_Celsius': 35,
-            'sda.Reallocated_Event_Count': 0,
-            'sda.Current_Pending_Sector': 0,
-            'sda.Offline_Uncorrectable': 0,
-            'sda.UDMA_CRC_Error_Count': 0,
-            'sda.Multi_Zone_Error_Rate': 0,
+
+            # attributes
+
+            'sda.pre-fail.spin_up_time.value': 175,
+            'sda.pre-fail.spin_up_time.worst': 175,
+            'sda.pre-fail.spin_up_time.thresh': 21,
+            'sda.pre-fail.spin_up_time.raw_val': 4225,
+
+            'sda.old_age.power_cycle_count.value': 100,
+            'sda.old_age.power_cycle_count.worst': 100,
+            'sda.old_age.power_cycle_count.thresh': 0,
+            'sda.old_age.power_cycle_count.raw_val': 13,
+
+            'sda.old_age.temperature_celsius.value': 112,
+            'sda.old_age.temperature_celsius.worst': 111,
+            'sda.old_age.temperature_celsius.thresh': 0,
+            'sda.old_age.temperature_celsius.raw_val': 35,
+
+            # value {force_prefails}
+
+            'sda.pre-fail.raw_read_error_rate.value': 200,
+            'sda.pre-fail.reallocated_sector_ct.value': 200,
+
+            # worst {force_prefails}
+
+            'sda.pre-fail.raw_read_error_rate.worst': 200,
+            'sda.pre-fail.reallocated_sector_ct.worst': 200,
+
+            # thresh {force_prefails}
+
+            'sda.pre-fail.raw_read_error_rate.thresh': 51,
+            'sda.pre-fail.reallocated_sector_ct.thresh': 140,
+
+            # raw_val {force_prefails}
+
+            'sda.pre-fail.raw_read_error_rate.raw_val': 0,
+            'sda.pre-fail.reallocated_sector_ct.raw_val': 0,
+
+            # aliases
+
+            'sda.old_age.udma_crc_errs.value': 200,
+            'sda.old_age.udma_crc_errs.worst': 200,
+            'sda.old_age.udma_crc_errs.thresh': 0,
+            'sda.old_age.udma_crc_errs.raw_val': 0
         }
 
         header_call = call('sda.ATTRIBUTE_NAME', 'RAW_VALUE')


### PR DESCRIPTION
added improvements for SmartCollector:

- aliases for attributes (for cases when smartctl returns 'unknown attribute')
- more options to control number of incoming metrics to graphite (instead of using regular expressions)
- added 'force_prefails' option to collect attributes of 'pre-fail' type by default

added new collector DirStatsCollector:

- collect full and allocated size / number days since last update / etc of given directories