### PR TITLE
fix TypeError: super(type, obj): obj must be an instance or subtype issue

### DIFF
--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -21,7 +21,7 @@ import glob
 import os
 import subprocess
 
-import diamond.collector
+from diamond.collector import Collector
 
 
 def flatten_dictionary(input, sep='.', prefix=None):
@@ -46,10 +46,10 @@ def flatten_dictionary(input, sep='.', prefix=None):
             yield (fullname, value)
 
 
-class CephCollector(diamond.collector.Collector):
+class CephCollector(Collector):
 
     def get_default_config_help(self):
-        config_help = super(CephCollector, self).get_default_config_help()
+        config_help = Collector.get_default_config_help(self)
         config_help.update({
             'socket_path': 'The location of the ceph monitoring sockets.'
                            ' Defaults to "/var/run/ceph"',
@@ -66,7 +66,7 @@ class CephCollector(diamond.collector.Collector):
         """
         Returns the default collector settings
         """
-        config = super(CephCollector, self).get_default_config()
+        config = Collector.get_default_config(self)
         config.update({
             'socket_path': '/var/run/ceph',
             'socket_prefix': 'ceph-',


### PR DESCRIPTION
When run diamond with ceph, collector  CephStatsCollector is failed to load due to "TypeError: super(type, obj): obj must be an instance or subtype of type".
According to the [link](https://thingspython.wordpress.com/2010/09/27/another-super-wrinkle-raising-typeerror/),  it's because the repeated calls to load_module act as a reload, the objects created using the old class no longer satisfy the isinstance test, so super will fail.
So remove super from code and call parent class instead.