### PR TITLE
Allow dashes and underscores in the tag names

### DIFF
--- a/src/diamond/handler/test/testtsdb.py
+++ b/src/diamond/handler/test/testtsdb.py
@@ -117,7 +117,7 @@ class TestTSDBdHandler(unittest.TestCase):
         config = configobj.ConfigObj()
         config['host'] = '127.0.0.1'
         config['port'] = '4242'
-        config['tags'] = 'tag1=tagv1 tag2=tagv2'
+        config['tags'] = 'tag1=tagv1 tag2=with-dash tag3=with_under'
         metric = Metric('servers.myhostname.cpu.cpu_count',
                         123, raw_value=123, timestamp=1234567,
                         host='myhostname', metric_type='GAUGE')
@@ -125,7 +125,7 @@ class TestTSDBdHandler(unittest.TestCase):
         handler.process(metric)
         body = ('[{"timestamp": 1234567, "metric": "cpu.cpu_count", "value": '
                 '123, "tags": {"hostname": "myhostname", "tag1": "tagv1", '
-                '"tag2": "tagv2"}}]')
+                '"tag2": "with-dash", "tag3": "with_under"}}]')
         header = {'Content-Type': 'application/json'}
         mock_urlopen.assert_called_with(self.url, body, header)
 

--- a/src/diamond/handler/tsdb.py
+++ b/src/diamond/handler/tsdb.py
@@ -118,7 +118,7 @@ class TSDBHandler(Handler):
             self.prefix = ""
         # tags
         self.tags = []
-        pattern = re.compile(r'([a-zA-Z0-9]+)=([a-zA-Z0-9]+)')
+        pattern = re.compile(r'([a-zA-Z0-9]+)=([a-zA-Z0-9_\-]+)')
         for (key, value) in re.findall(pattern, str(self.config['tags'])):
             self.tags.append([key, value])
 


### PR DESCRIPTION
These characters are allowed in both tag and metric names as per
http://opentsdb.net/docs/build/html/user_guide/query/timeseries.html#precisions-on-metrics-and-tags