### PR TITLE
Changed custom version separator

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -24,7 +24,7 @@ if [ -e localversion ]; then
     LOCAL_REV=$(cat localversion)
     if [ -n "${LOCAL_REV}" ];
     then
-        LOCAL_REV="-${LOCAL_REV}"
+        LOCAL_REV="_${LOCAL_REV}"
     fi
 fi
 


### PR DESCRIPTION
I tried to generate yesterday a deb package with a custom version and i saw that debuild shows an error when trying to generate a package with a '-' in the version unless you use the **DEBUILD_TGZ_CHECK=no** config. 