### PR TITLE
docker_collector.py: support docker python module (issue 687).

### DIFF
--- a/src/collectors/docker_collector/docker_collector.py
+++ b/src/collectors/docker_collector/docker_collector.py
@@ -19,6 +19,7 @@ except ImportError:
     docker = None
 else:
     DockerClient = docker.Client if docker.version < "2" else docker.APIClient
+    
 
 class DockerCollector(diamond.collector.Collector):
 

--- a/src/collectors/docker_collector/docker_collector.py
+++ b/src/collectors/docker_collector/docker_collector.py
@@ -17,7 +17,8 @@ try:
     import docker
 except ImportError:
     docker = None
-
+else:
+    DockerClient = docker.Client if docker.version < "2" else docker.APIClient
 
 class DockerCollector(diamond.collector.Collector):
 
@@ -63,7 +64,7 @@ class DockerCollector(diamond.collector.Collector):
 
         # Collect info
         results = {}
-        client = docker.Client(version='auto')
+        client = DockerClient(version='auto')
 
         # Top level stats
         running_containers = client.containers()

--- a/src/collectors/docker_collector/docker_collector.py
+++ b/src/collectors/docker_collector/docker_collector.py
@@ -19,7 +19,7 @@ except ImportError:
     docker = None
 else:
     DockerClient = docker.Client if docker.version < "2" else docker.APIClient
-    
+
 
 class DockerCollector(diamond.collector.Collector):
 


### PR DESCRIPTION
Little fix for docker_collector so it can work both with docker-py and docker(newer version of docker-py) python modules.
Fix for [this](https://github.com/python-diamond/Diamond/issues/687) issue.