### PR TITLE
diskspace.py: Fixed ZeroDivisionError when blocks_free is 0 and nfs mounts

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -232,8 +232,11 @@ class DiskSpaceCollector(diamond.collector.Collector):
 
             for unit in self.config['byte_unit']:
                 metric_name = '%s.%s_percentfree' % (name, unit)
-                metric_value = float(blocks_free) / float(
-                    blocks_free + (blocks_total - blocks_free)) * 100
+                try:
+                    metric_value = float(blocks_free) / float(
+                        blocks_free + (blocks_total - blocks_free)) * 100
+                except ZeroDivisionError:
+                    metric_value = 0
                 self.publish_gauge(metric_name, metric_value, 2)
 
                 metric_name = '%s.%s_used' % (name, unit)

--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -144,7 +144,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
                                    "exclude_filter list.", mount_point)
                     continue
 
-                if ((('/' in device or device == 'tmpfs') and
+                if ((('/' in device or ':' in device or device == 'tmpfs') and
                      mount_point.startswith('/'))):
                     try:
                         stat = os.stat(mount_point)


### PR DESCRIPTION
Fixed that collector stopps operation for all filesystems when one filesystem has zero blocks_free:

```
[2018-03-05` 12:14:39,245] [ERROR] [MainThread:DiskSpaceCollector] Collector failed!
Traceback (most recent call last):
  File "/python2.7/site-packages/diamond/utils/scheduler.py", line 73, in collector_process
    collector._run()
  File "/python2.7/site-packages/diamond/collector.py", line 477, in _run
    self.collect()
  File "/share/diamond/collectors/diskspace/diskspace.py", line 243, in collect
    blocks_free + (blocks_total - blocks_free)) * 100
ZeroDivisionError: float division by zero
```
