### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,3 @@ notifications:
 addons:
     apt_packages:
     - libsensors4
-
-branches:
-  only:
-    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 language: python
 python:
-  - "2.6"
   - "2.7"
 
 cache:
@@ -16,7 +15,6 @@ install:
     - pip install -r .travis.requirements.txt
     - pip install pep8==1.5.7
     - pip install coveralls
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
 
 # command to run tests, e.g. python setup.py test
 script:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,7 +88,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     c.vm.provision "shell", inline: "sudo mkdir /var/log/diamond"
     c.vm.provision "shell", inline: "sudo ln -s /vagrant/conf/vagrant /etc/diamond"
     c.vm.provision "shell", inline: "sudo ln -s /vagrant/bin/diamond /usr/bin/diamond"
-    c.vm.provision "shell", inline: "sudo ln -s /vagrant/src/diamond /usr/lib/python2.6/site-packages/diamond"
+    c.vm.provision "shell", inline: "sudo ln -s /vagrant/src/diamond /usr/lib/python2.7/site-packages/diamond"
     c.vm.provision "shell", inline: "sudo ln -s /vagrant/bin/init.d/diamond /etc/init.d/diamond"
 
     # Start diamond

--- a/bin/diamond
+++ b/bin/diamond
@@ -304,7 +304,7 @@ def main():
                     # join() on each of them. This guarantees that the
                     # SyncManager is terminated last (implicitly as a result of
                     # us exiting).
-                    child_debug = "Terminating and joining on: {0} ({1})"
+                    child_debug = "Terminating and joining on: {} ({})"
                     log.debug(child_debug.format(child.name, child.pid))
                     child.terminate()
                     child.join()

--- a/bin/diamond
+++ b/bin/diamond
@@ -127,10 +127,10 @@ def main():
         log = setup_logging(options.configfile, options.log_stdout)
 
     # Pass the exit up stream rather then handle it as an general exception
-    except SystemExit, e:
+    except SystemExit as e:
         raise SystemExit
 
-    except Exception, e:
+    except Exception as e:
         import traceback
         sys.stderr.write("Unhandled exception: %s" % str(e))
         sys.stderr.write("traceback: %s" % traceback.format_exc())
@@ -186,7 +186,7 @@ def main():
                 pid = str(os.getpid())
                 try:
                     pf = file(options.pidfile, 'w+')
-                except IOError, e:
+                except IOError as e:
                     print >> sys.stderr, "Failed to write PID file: %s" % (e)
                     sys.exit(1)
                 pf.write("%s\n" % pid)
@@ -211,7 +211,7 @@ def main():
                     # Set UID
                     os.setuid(uid)
 
-            except Exception, e:
+            except Exception as e:
                 print >> sys.stderr, "ERROR: Failed to set UID/GID. %s" % (e)
                 sys.exit(1)
 
@@ -236,7 +236,7 @@ def main():
                     if pid > 0:
                         # Exit first paren
                         sys.exit(0)
-                except OSError, e:
+                except OSError as e:
                     print >> sys.stderr, "Failed to fork process." % (e)
                     sys.exit(1)
                 # Decouple from parent environmen
@@ -248,7 +248,7 @@ def main():
                     if pid > 0:
                         # Exit second paren
                         sys.exit(0)
-                except OSError, e:
+                except OSError as e:
                     print >> sys.stderr, "Failed to fork process." % (e)
                     sys.exit(1)
                 # Close file descriptors so that we can detach
@@ -269,7 +269,7 @@ def main():
                 pid = str(os.getpid())
                 try:
                     pf = file(options.pidfile, 'w+')
-                except IOError, e:
+                except IOError as e:
                     log.error("Failed to write child PID file: %s" % (e))
                     sys.exit(1)
                 pf.write("%s\n" % pid)
@@ -317,10 +317,10 @@ def main():
         server.run()
 
     # Pass the exit up stream rather then handle it as an general exception
-    except SystemExit, e:
+    except SystemExit as e:
         raise SystemExit
 
-    except Exception, e:
+    except Exception as e:
         import traceback
         log.error("Unhandled exception: %s" % str(e))
         log.error("traceback: %s" % traceback.format_exc())

--- a/bin/diamond
+++ b/bin/diamond
@@ -201,14 +201,7 @@ def main():
             try:
                 if gid != -1 and uid != -1:
                     # Manually set the groups since they aren't set by default
-
-                    # Python 2.7+
-                    if hasattr(os, 'initgroups'):
-                        os.initgroups(user, gid)
-                    # Python 2.6
-                    else:
-                        os.setgroups([e.gr_gid for e in grp.getgrall()
-                                      if user in e.gr_mem] + [gid])
+                    os.initgroups(user, gid)
 
                 if gid != -1 and os.getgid() != gid:
                     # Set GID

--- a/bin/diamond
+++ b/bin/diamond
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 
+from __future__ import print_function
 import os
 import sys
 import configobj
@@ -110,7 +111,7 @@ def main():
         gid = -1
 
         if options.version:
-            print "Diamond version %s" % (get_diamond_version())
+            print("Diamond version %s" % (get_diamond_version()))
             sys.exit(0)
 
         # Initialize Config
@@ -118,8 +119,8 @@ def main():
         if os.path.exists(options.configfile):
             config = configobj.ConfigObj(options.configfile)
         else:
-            print >> sys.stderr, "ERROR: Config file: %s does not exist." % (
-                options.configfile)
+            print("ERROR: Config file: %s does not exist." % (
+                options.configfile), file=sys.stderr)
             parser.print_help(sys.stderr)
             sys.exit(1)
 
@@ -159,11 +160,11 @@ def main():
                     # Pid is not real
                     os.unlink(options.pidfile)
                     pid = None
-                    print >> sys.stderr, (
-                        "WARN: Bogus pid file was found. I deleted it.")
+                    print("WARN: Bogus pid file was found. I deleted it.",
+                          file=sys.stderr)
                 else:
-                    print >> sys.stderr, (
-                        "ERROR: Pidfile exists. Server already running?")
+                    print("ERROR: Pidfile exists. Server already running?",
+                          file=sys.stderr)
                     sys.exit(1)
 
             # Get final GIDs
@@ -187,7 +188,7 @@ def main():
                 try:
                     pf = file(options.pidfile, 'w+')
                 except IOError as e:
-                    print >> sys.stderr, "Failed to write PID file: %s" % (e)
+                    print("Failed to write PID file: %s" % (e), file=sys.stderr)
                     sys.exit(1)
                 pf.write("%s\n" % pid)
                 pf.close()
@@ -212,7 +213,8 @@ def main():
                     os.setuid(uid)
 
             except Exception as e:
-                print >> sys.stderr, "ERROR: Failed to set UID/GID. %s" % (e)
+                print("ERROR: Failed to set UID/GID. %s" % (e),
+                      file=sys.stderr)
                 sys.exit(1)
 
             # Log
@@ -237,7 +239,7 @@ def main():
                         # Exit first paren
                         sys.exit(0)
                 except OSError as e:
-                    print >> sys.stderr, "Failed to fork process." % (e)
+                    print("Failed to fork process." % (e), file=sys.stderr)
                     sys.exit(1)
                 # Decouple from parent environmen
                 os.setsid()
@@ -249,7 +251,7 @@ def main():
                         # Exit second paren
                         sys.exit(0)
                 except OSError as e:
-                    print >> sys.stderr, "Failed to fork process." % (e)
+                    print("Failed to fork process." % (e), file=sys.stderr)
                     sys.exit(1)
                 # Close file descriptors so that we can detach
                 sys.stdout.close()

--- a/bin/diamond-setup
+++ b/bin/diamond-setup
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 ##########################################################################
 
+from __future__ import print_function
 import os
 import sys
 import optparse
@@ -63,10 +64,10 @@ def getCollectors(path):
                             break
                     except TypeError:
                         continue
-                # print "Imported module: %s %s" % (modname, cls.__name__)
+                # print("Imported module: %s %s" % (modname, cls.__name__))
             except Exception:
-                print "Failed to import module: %s. %s" % (
-                    modname, traceback.format_exc())
+                print("Failed to import module: %s. %s" % (
+                    modname, traceback.format_exc()))
                 collectors[modname] = False
                 continue
 
@@ -133,9 +134,9 @@ def configureKey(key):
     except NotImplementedError:
         return
 
-    print "\n"
+    print("\n")
     if key in default_conf_help:
-        print default_conf_help[key]
+        print(default_conf_help[key])
     val = raw_input(key + ' [' + user_val + ']: ')
 
     # Empty user input? Default to current value
@@ -177,18 +178,18 @@ if __name__ == "__main__":
     if os.path.exists(options.configfile):
         config = ConfigObj(os.path.abspath(options.configfile))
     else:
-        print >> sys.stderr, "ERROR: Config file: %s does not exist." % (
-            options.configfile)
-        print >> sys.stderr, ("Please run python config.py -c"
-                              + " /path/to/diamond.conf")
+        print("ERROR: Config file: %s does not exist." % (
+            options.configfile), file=sys.stderr)
+        print("Please run python config.py -c /path/to/diamond.conf",
+              file=sys.stderr)
         parser.print_help(sys.stderr)
         sys.exit(1)
 
     if not options.dump:
-        print ''
-        print 'I will be over writing files in'
-        print config['server']['collectors_config_path']
-        print 'Please type yes to continue'
+        print('')
+        print('I will be over writing files in')
+        print(config['server']['collectors_config_path'])
+        print('Please type yes to continue')
 
         val = raw_input('Are you sure? ')
         if val != 'yes':
@@ -225,7 +226,7 @@ if __name__ == "__main__":
             obj = cls(config=config, handlers={})
 
             if options.dump:
-                print collector + " " + str(obj.config)
+                print(collector + " " + str(obj.config))
                 continue
 
             default_conf = obj.get_default_config()
@@ -241,11 +242,11 @@ if __name__ == "__main__":
             config_keys['instance_prefix'] = False
             config_keys['interval'] = False
 
-            print "*" * 60
-            print "\n\t\tNow configuring " + collector
-            print collectors[collector].__doc__
+            print("*" * 60)
+            print("\n\t\tNow configuring " + collector)
+            print(collectors[collector].__doc__)
 
-            print "(%s)" % collector
+            print("(%s)" % collector)
             configureKey('enabled')
 
             if boolCheck(config_file['enabled']):
@@ -257,11 +258,11 @@ if __name__ == "__main__":
             config_file.write()
 
         except IOError, (errno, strerror):
-            print "I/O error({}): {}".format(errno, strerror)
+            print("I/O error({}): {}".format(errno, strerror))
         except KeyboardInterrupt:
-            print
+            print()
             sys.exit()
         except:
             continue
     if not foundcollector:
-        print "Collector not found."
+        print("Collector not found.")

--- a/bin/diamond-setup
+++ b/bin/diamond-setup
@@ -257,7 +257,7 @@ if __name__ == "__main__":
 
             config_file.write()
 
-        except IOError, (errno, strerror):
+        except IOError as (errno, strerror):
             print("I/O error({}): {}".format(errno, strerror))
         except KeyboardInterrupt:
             print()

--- a/bin/diamond-setup
+++ b/bin/diamond-setup
@@ -257,7 +257,7 @@ if __name__ == "__main__":
             config_file.write()
 
         except IOError, (errno, strerror):
-            print "I/O error({0}): {1}".format(errno, strerror)
+            print "I/O error({}): {}".format(errno, strerror)
         except KeyboardInterrupt:
             print
             sys.exit()

--- a/build_doc.py
+++ b/build_doc.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 ##########################################################################
 
+from __future__ import print_function
 import configobj
 import optparse
 import os
@@ -56,8 +57,8 @@ def getCollectors(path):
                     if cls.__name__ not in collectors:
                         collectors[cls.__name__] = module
             except Exception:
-                print "Failed to import module: %s. %s" % (
-                    modname, traceback.format_exc())
+                print("Failed to import module: %s. %s" % (
+                    modname, traceback.format_exc()))
                 collectors[modname] = False
 
         elif os.path.isdir(cPath):
@@ -91,8 +92,8 @@ def getHandlers(path, name=None):
                     if cls.__name__ not in handlers:
                         handlers[cls.__name__] = module
             except Exception:
-                print "Failed to import module: %s. %s" % (
-                    modname, traceback.format_exc())
+                print("Failed to import module: %s. %s" % (
+                    modname, traceback.format_exc()))
                 handlers[modname] = False
 
         elif os.path.isdir(cPath):
@@ -110,7 +111,7 @@ def writeDocString(docFile, name, doc):
     docFile.write("%s\n" % (name))
     docFile.write("=====\n")
     if doc is None:
-        print "No __doc__ string for %s!" % name
+        print("No __doc__ string for %s!" % name)
     docFile.write("%s\n" % doc)
 
 
@@ -150,7 +151,7 @@ def writeDoc(items, type_name, doc_path):
         if item.startswith('Test'):
             continue
 
-        print "Processing %s..." % (item)
+        print("Processing %s..." % (item))
 
         if not hasattr(items[item], item):
             continue
@@ -173,7 +174,7 @@ def writeDoc(items, type_name, doc_path):
             if type_name is "Handler":
                 os.remove(tmpfile[1])
         except Exception as e:
-            print "Caught Exception %s" % e
+            print("Caught Exception {}".format(e))
 
         docFile = open(os.path.join(doc_path, item + ".md"), 'w')
 
@@ -226,10 +227,10 @@ if __name__ == "__main__":
     if os.path.exists(options.configfile):
         config = configobj.ConfigObj(os.path.abspath(options.configfile))
     else:
-        print >> sys.stderr, "ERROR: Config file: %s does not exist." % (
-            options.configfile)
-        print >> sys.stderr, ("Please run python config.py -c " +
-                              "/path/to/diamond.conf")
+        print("ERROR: Config file: %s does not exist." % (
+            options.configfile), file=sys.stderr)
+        print(("Please run python config.py -c /path/to/diamond.conf"),
+              file=sys.stderr)
         parser.print_help(sys.stderr)
         sys.exit(1)
 

--- a/build_doc.py
+++ b/build_doc.py
@@ -177,8 +177,6 @@ def writeDoc(items, type_name, doc_path):
 
         docFile = open(os.path.join(doc_path, item + ".md"), 'w')
 
-        enabled = ''
-
         writeDocHeader(docFile)
         writeDocString(docFile, item, items[item].__doc__)
         writeDocOptionsHeader(docFile)

--- a/build_doc.py
+++ b/build_doc.py
@@ -172,7 +172,7 @@ def writeDoc(items, type_name, doc_path):
             default_options = obj.get_default_config()
             if type_name is "Handler":
                 os.remove(tmpfile[1])
-        except Exception, e:
+        except Exception as e:
             print "Caught Exception %s" % e
 
         docFile = open(os.path.join(doc_path, item + ".md"), 'w')

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -4,7 +4,7 @@
 ### Core
 
 - CentOS or Ubuntu
-- Python 2.6+
+- Python 2.7
 - python-configobj
 - python-setuptools
 - make

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ setup(
     packages=['diamond', 'diamond.handler', 'diamond.utils'],
     scripts=['bin/diamond', 'bin/diamond-setup'],
     data_files=data_files,
+    python_requires='==2.7',
     install_requires=install_requires,
     classifiers=[
         'Programming Language :: Python',

--- a/src/collectors/amavis/amavis.py
+++ b/src/collectors/amavis/amavis.py
@@ -89,7 +89,7 @@ class AmavisCollector(diamond.collector.Collector):
                             if metric in ('count', 'time'):
                                 mtype = 'COUNTER'
                                 precision = 0
-                            self.publish("{0}.{1}".format(name, metric),
+                            self.publish("{}.{}".format(name, metric),
                                          value, metric_type=mtype,
                                          precision=precision)
 

--- a/src/collectors/beanstalkd/beanstalkd.py
+++ b/src/collectors/beanstalkd/beanstalkd.py
@@ -51,7 +51,7 @@ class BeanstalkdCollector(diamond.collector.Collector):
         try:
             connection = beanstalkc.Connection(self.config['host'],
                                                int(self.config['port']))
-        except beanstalkc.BeanstalkcException, e:
+        except beanstalkc.BeanstalkcException as e:
             self.log.error("Couldn't connect to beanstalkd: %s", e)
             return {}
 

--- a/src/collectors/bind/bind.py
+++ b/src/collectors/bind/bind.py
@@ -71,7 +71,7 @@ class BindCollector(diamond.collector.Collector):
         try:
             req = urllib2.urlopen('http://%s:%d/' % (
                 self.config['host'], int(self.config['port'])))
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldnt connect to bind: %s', e)
             return {}
 

--- a/src/collectors/bind/bind.py
+++ b/src/collectors/bind/bind.py
@@ -11,7 +11,6 @@ Collects stats from bind 9.5's statistics server
 """
 
 import diamond.collector
-import sys
 import urllib2
 import xml.etree.cElementTree as ElementTree
 

--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -108,7 +108,7 @@ class CephCollector(diamond.collector.Collector):
                  'perf',
                  'dump',
                  ])
-        except subprocess.CalledProcessError, err:
+        except subprocess.CalledProcessError as err:
             self.log.info('Could not get stats from %s: %s',
                           name, err)
             self.log.exception('Could not get stats from %s' % name)
@@ -116,7 +116,7 @@ class CephCollector(diamond.collector.Collector):
 
         try:
             json_data = json.loads(json_blob)
-        except Exception, err:
+        except Exception as err:
             self.log.info('Could not parse stats from %s: %s',
                           name, err)
             self.log.exception('Could not parse stats from %s' % name)

--- a/src/collectors/cephstats/cephstats.py
+++ b/src/collectors/cephstats/cephstats.py
@@ -68,7 +68,7 @@ class CephStatsCollector(CephCollector):
         """
         try:
             output = subprocess.check_output(['ceph', '-s'])
-        except subprocess.CalledProcessError, err:
+        except subprocess.CalledProcessError as err:
             self.log.info(
                 'Could not get stats: %s' % err)
             self.log.exception('Could not get stats')

--- a/src/collectors/chronyd/chronyd.py
+++ b/src/collectors/chronyd/chronyd.py
@@ -78,7 +78,7 @@ class ChronydCollector(diamond.collector.Collector):
 
             try:
                 value = diamond.convertor.time.convert(offset, unit, 'ms')
-            except NotImplementedError, e:
+            except NotImplementedError as e:
                 self.log.error('Unable to convert %s%s: %s', offset, unit, e)
                 continue
 

--- a/src/collectors/cpu/cpu.py
+++ b/src/collectors/cpu/cpu.py
@@ -143,8 +143,7 @@ class CPUCollector(diamond.collector.Collector):
             # Close File
             file.close()
 
-            metrics = {}
-            metrics['cpu_count'] = ncpus
+            metrics = {'cpu_count': ncpus}
 
             for cpu in results.keys():
                 stats = results[cpu]

--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -201,7 +201,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
             if hasattr(os, 'statvfs'):  # POSIX
                 try:
                     data = os.statvfs(info['mount_point'])
-                except OSError, e:
+                except OSError as e:
                     self.log.exception(e)
                     continue
 

--- a/src/collectors/diskspace/test/testdiskspace.py
+++ b/src/collectors/diskspace/test/testdiskspace.py
@@ -5,7 +5,6 @@
 from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
-from test import run_only
 from mock import Mock
 from mock import patch
 

--- a/src/collectors/docker_collector/docker_collector.py
+++ b/src/collectors/docker_collector/docker_collector.py
@@ -51,7 +51,7 @@ class DockerCollector(diamond.collector.Collector):
         cur = dictionary
         for key in keys:
             if not isinstance(cur, dict):
-                raise Exception("metric '{0}' does not exist".format(path))
+                raise Exception("metric '{}' does not exist".format(path))
             cur = cur.get(key)
             if cur is None:
                 break

--- a/src/collectors/docker_collector/test/testdocker_collector.py
+++ b/src/collectors/docker_collector/test/testdocker_collector.py
@@ -13,7 +13,6 @@ try:
 except ImportError:
     Client = None
 
-from diamond.collector import Collector
 from docker_collector import DockerCollector
 
 dirname = os.path.dirname(__file__)

--- a/src/collectors/drbd/drbd.py
+++ b/src/collectors/drbd/drbd.py
@@ -75,7 +75,7 @@ class DRBDCollector(diamond.collector.Collector):
                 else:
                     continue
             statusfile.close()
-        except IOError, errormsg:
+        except IOError as errormsg:
             self.log.error("Can't read DRBD status file: {}".format(errormsg))
             return
 

--- a/src/collectors/drbd/drbd.py
+++ b/src/collectors/drbd/drbd.py
@@ -76,7 +76,7 @@ class DRBDCollector(diamond.collector.Collector):
                     continue
             statusfile.close()
         except IOError, errormsg:
-            self.log.error("Can't read DRBD status file: {0}".format(errormsg))
+            self.log.error("Can't read DRBD status file: {}".format(errormsg))
             return
 
         for resource in results.keys():

--- a/src/collectors/dropwizard/dropwizard.py
+++ b/src/collectors/dropwizard/dropwizard.py
@@ -46,7 +46,7 @@ class DropwizardCollector(diamond.collector.Collector):
             self.config['host'], int(self.config['port']))
         try:
             response = urllib2.urlopen(url)
-        except urllib2.HTTPError, err:
+        except urllib2.HTTPError as err:
             self.log.error("%s: %s", url, err)
             return
 

--- a/src/collectors/dseopscenter/dseopscenter.py
+++ b/src/collectors/dseopscenter/dseopscenter.py
@@ -120,7 +120,7 @@ class DseOpsCenterCollector(diamond.collector.Collector):
                                              self.config['cluster_id'])
         try:
             response = urllib2.urlopen(url)
-        except Exception, err:
+        except Exception as err:
             self.log.error('%s: %s', url, err)
             return False
 
@@ -158,7 +158,7 @@ class DseOpsCenterCollector(diamond.collector.Collector):
 
         try:
             response = urllib2.urlopen(url)
-        except Exception, err:
+        except Exception as err:
             self.log.error('%s: %s', url, err)
             return False
 

--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -117,7 +117,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
                     '%s:%s' % (self.config['user'], self.config['password']))
                 request.add_header("Authorization", "Basic %s" % base64string)
             response = urllib2.urlopen(request)
-        except Exception, err:
+        except Exception as err:
             self.log.error("%s: %s" % (url, err))
             return False
 

--- a/src/collectors/elb/elb.py
+++ b/src/collectors/elb/elb.py
@@ -108,6 +108,7 @@ def utc_to_local(utc_dt):
 @memoized
 def get_zones(region, auth_kwargs):
     """
+    :param auth_kwargs:
     :param region: region to get the availability zones for
     :return: list of availability zones
     """

--- a/src/collectors/elb/test/testelb.py
+++ b/src/collectors/elb/test/testelb.py
@@ -203,7 +203,7 @@ def assertRaisesAndContains(excClass, contains_str, callableObj, *args,
                             **kwargs):
     try:
         callableObj(*args, **kwargs)
-    except excClass, e:
+    except excClass as e:
         msg = str(e)
         if contains_str in msg:
             return

--- a/src/collectors/endecadgraph/endecadgraph.py
+++ b/src/collectors/endecadgraph/endecadgraph.py
@@ -15,7 +15,6 @@ import diamond.collector
 import urllib2
 from StringIO import StringIO
 import re
-import sys
 import xml.etree.cElementTree as ElementTree
 
 

--- a/src/collectors/endecadgraph/endecadgraph.py
+++ b/src/collectors/endecadgraph/endecadgraph.py
@@ -105,14 +105,14 @@ class EndecaDgraphCollector(diamond.collector.Collector):
                             processElem(elem, elemList)
                     elif event == 'end':
                         elemList.pop()
-            except Exception, e:
+            except Exception as e:
                 self.log.error('Something went wrong: %s', e)
 
         url = 'http://%s:%d/admin?op=stats' % (self.config['host'],
                                                self.config['port'])
         try:
             xml = urllib2.urlopen(url, timeout=self.config['timeout']).read()
-        except Exception, e:
+        except Exception as e:
             self.log.error('Could not connect to endeca on %s: %s' % (url, e))
             return {}
 

--- a/src/collectors/etcdstat/etcdstat.py
+++ b/src/collectors/etcdstat/etcdstat.py
@@ -101,7 +101,7 @@ class EtcdCollector(diamond.collector.Collector):
                                               self.config['port'], category)
 
             return json.load(urllib2.urlopen(url, **opts))
-        except (urllib2.HTTPError, ValueError), err:
+        except (urllib2.HTTPError, ValueError) as err:
             self.log.error('Unable to read JSON response: %s' % err)
             return {}
 

--- a/src/collectors/eventstoreprojections/tests/testeventstoreprojections.py
+++ b/src/collectors/eventstoreprojections/tests/testeventstoreprojections.py
@@ -5,7 +5,7 @@
 from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
-from mock import call, patch
+from mock import patch
 
 from diamond.collector import Collector
 

--- a/src/collectors/fluentd/test/testfluentd.py
+++ b/src/collectors/fluentd/test/testfluentd.py
@@ -7,7 +7,6 @@ from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
 
-from diamond.collector import Collector
 from fluentd import FluentdCollector
 
 

--- a/src/collectors/flume/flume.py
+++ b/src/collectors/flume/flume.py
@@ -83,14 +83,14 @@ class FlumeCollector(diamond.collector.Collector):
             try:
                 j = json.loads(resp.read())
                 resp.close()
-            except Exception, e:
+            except Exception as e:
                 resp.close()
                 self.log.error('Cannot load json data: %s', e)
                 return None
-        except urllib2.URLError, e:
+        except urllib2.URLError as e:
             self.log.error('Failed to open url: %s', e)
             return None
-        except Exception, e:
+        except Exception as e:
             self.log.error('Unknown error opening url: %s', e)
             return None
 

--- a/src/collectors/flume/flume.py
+++ b/src/collectors/flume/flume.py
@@ -72,7 +72,7 @@ class FlumeCollector(diamond.collector.Collector):
         return default_config
 
     def collect(self):
-        url = 'http://{0}:{1}{2}'.format(
+        url = 'http://{}:{}{}'.format(
             self.config['req_host'],
             self.config['req_port'],
             self.config['req_path']
@@ -101,11 +101,11 @@ class FlumeCollector(diamond.collector.Collector):
 
             for item in self._metrics_collect[comp_type]:
                 if item.endswith('Count'):
-                    metric_name = '{0}.{1}'.format(comp_name, item[:-5])
+                    metric_name = '{}.{}'.format(comp_name, item[:-5])
                     metric_value = int(comp_items[item])
                     self.publish_counter(metric_name, metric_value)
                 elif item.endswith('Percentage'):
-                    metric_name = '{0}.{1}'.format(comp_name, item)
+                    metric_name = '{}.{}'.format(comp_name, item)
                     metric_value = float(comp_items[item])
                     self.publish_gauge(metric_name, metric_value)
                 else:

--- a/src/collectors/haproxy/haproxy.py
+++ b/src/collectors/haproxy/haproxy.py
@@ -68,7 +68,7 @@ class HAProxyCollector(diamond.collector.Collector):
         try:
             handle = urllib2.urlopen(req)
             return handle.readlines()
-        except Exception, e:
+        except Exception as e:
             if not hasattr(e, 'code') or e.code != 401:
                 self.log.error("Error retrieving HAProxy stats. %s", e)
                 return metrics
@@ -104,7 +104,7 @@ class HAProxyCollector(diamond.collector.Collector):
             handle = urllib2.urlopen(req)
             metrics = handle.readlines()
             return metrics
-        except IOError, e:
+        except IOError as e:
             # here we shouldn't fail if the USER/PASS is right
             self.log.error("Error retrieving HAProxy stats. " +
                            "(Invalid username or password?) %s", e)
@@ -122,7 +122,7 @@ class HAProxyCollector(diamond.collector.Collector):
                 if not buf:
                     break
                 data += buf
-        except socket.error, e:
+        except socket.error as e:
             self.log.error("Error retrieving HAProxy stats. %s", e)
             return []
 

--- a/src/collectors/http/http.py
+++ b/src/collectors/http/http.py
@@ -86,8 +86,8 @@ class HttpCollector(diamond.collector.Collector):
                     metric_name + '.size',
                     len(the_page))
 
-            except IOError, e:
+            except IOError as e:
                 self.log.error("Unable to open %s",
                                self.config['req_url'])
-            except Exception, e:
+            except Exception as e:
                 self.log.error("Unknown error opening url: %s", e)

--- a/src/collectors/httpd/httpd.py
+++ b/src/collectors/httpd/httpd.py
@@ -93,7 +93,7 @@ class HttpdCollector(diamond.collector.Collector):
                         break
                     url = headers['location']
                     connection.close()
-            except Exception, e:
+            except Exception as e:
                 self.log.error(
                     "Error retrieving HTTPD stats for host %s:%s, url '%s': %s",
                     service_host, str(service_port), url, e)

--- a/src/collectors/httpd/httpd.py
+++ b/src/collectors/httpd/httpd.py
@@ -173,16 +173,14 @@ class HttpdCollector(diamond.collector.Collector):
 
     def _parseScoreboard(self, sb):
 
-        ret = []
-
-        ret.append(('IdleWorkers', sb.count('_')))
-        ret.append(('ReadingWorkers', sb.count('R')))
-        ret.append(('WritingWorkers', sb.count('W')))
-        ret.append(('KeepaliveWorkers', sb.count('K')))
-        ret.append(('DnsWorkers', sb.count('D')))
-        ret.append(('ClosingWorkers', sb.count('C')))
-        ret.append(('LoggingWorkers', sb.count('L')))
-        ret.append(('FinishingWorkers', sb.count('G')))
-        ret.append(('CleanupWorkers', sb.count('I')))
+        ret = [('IdleWorkers', sb.count('_')),
+               ('ReadingWorkers', sb.count('R')),
+               ('WritingWorkers', sb.count('W')),
+               ('KeepaliveWorkers', sb.count('K')),
+               ('DnsWorkers', sb.count('D')),
+               ('ClosingWorkers', sb.count('C')),
+               ('LoggingWorkers', sb.count('L')),
+               ('FinishingWorkers', sb.count('G')),
+               ('CleanupWorkers', sb.count('I'))]
 
         return ret

--- a/src/collectors/ip/ip.py
+++ b/src/collectors/ip/ip.py
@@ -51,8 +51,8 @@ class IPCollector(diamond.collector.Collector):
         return config_help
 
     def get_default_config(self):
-        ''' Returns the default collector settings
-        '''
+        """ Returns the default collector settings
+        """
         config = super(IPCollector, self).get_default_config()
         config.update({
             'path': 'ip',

--- a/src/collectors/jbossapi/jbossapi.py
+++ b/src/collectors/jbossapi/jbossapi.py
@@ -357,7 +357,7 @@ class JbossApiCollector(diamond.collector.Collector):
                                           stdout=subprocess.PIPE
                                           ).communicate()[0]
             output = json.loads(attributes)
-        except Exception, e:
+        except Exception as e:
             self.log.error("JbossApiCollector: There was an exception %s", e)
             output = ''
         return output

--- a/src/collectors/jcollectd/collectd_network.py
+++ b/src/collectors/jcollectd/collectd_network.py
@@ -26,12 +26,12 @@ Collectd network protocol implementation.
 import socket
 import struct
 import select
-import platform
+import sys
 from datetime import datetime
 from copy import deepcopy
 
-if platform.python_version() < '2.8.0':
-    # Python 2.7 and below io.StringIO does not like unicode
+if sys.version_info.major == 2:
+    # Python 2.7 io.StringIO does not like unicode
     from StringIO import StringIO
 else:
     try:

--- a/src/collectors/jcollectd/jcollectd.py
+++ b/src/collectors/jcollectd/jcollectd.py
@@ -121,7 +121,7 @@ class ListenerThread(threading.Thread):
         self.queue = Queue.Queue()
 
     def run(self):
-        self.log.info('ListenerThread started on {0}:{1}(udp)'.format(
+        self.log.info('ListenerThread started on {}:{}(udp)'.format(
             self.host, self.port))
 
         rdr = collectd_network.Reader(self.host, self.port)
@@ -132,10 +132,10 @@ class ListenerThread(threading.Thread):
                     items = rdr.interpret(poll_interval=self.poll_interval)
                     self.send_to_collector(items)
                 except ValueError, e:
-                    self.log.warn('Dropping bad packet: {0}'.format(e))
+                    self.log.warn('Dropping bad packet: {}'.format(e))
         except Exception, e:
-            self.log.error('caught exception: type={0}, exc={1}'.format(type(e),
-                                                                        e))
+            self.log.error('caught exception: type={}, exc={}'.format(
+                type(e), e))
 
         self.log.info('ListenerThread - stop')
 
@@ -150,8 +150,8 @@ class ListenerThread(threading.Thread):
             except Queue.Full:
                 self.log.error('Queue to collector is FULL')
             except Exception, e:
-                self.log.error('B00M! type={0}, exception={1}'.format(type(e),
-                                                                      e))
+                self.log.error('B00M! type={}, exception={}'.format(
+                    type(e), e))
 
     def transform(self, item):
 

--- a/src/collectors/jcollectd/jcollectd.py
+++ b/src/collectors/jcollectd/jcollectd.py
@@ -131,9 +131,9 @@ class ListenerThread(threading.Thread):
                 try:
                     items = rdr.interpret(poll_interval=self.poll_interval)
                     self.send_to_collector(items)
-                except ValueError, e:
+                except ValueError as e:
                     self.log.warn('Dropping bad packet: {}'.format(e))
-        except Exception, e:
+        except Exception as e:
             self.log.error('caught exception: type={}, exc={}'.format(
                 type(e), e))
 
@@ -149,7 +149,7 @@ class ListenerThread(threading.Thread):
                 self.queue.put(metric)
             except Queue.Full:
                 self.log.error('Queue to collector is FULL')
-            except Exception, e:
+            except Exception as e:
                 self.log.error('B00M! type={}, exception={}'.format(
                     type(e), e))
 

--- a/src/collectors/jolokia/cassandra_jolokia.py
+++ b/src/collectors/jolokia/cassandra_jolokia.py
@@ -22,7 +22,6 @@ CassandraJolokiaCollector.conf
 
 from jolokia import JolokiaCollector
 import math
-import string
 import re
 
 

--- a/src/collectors/jolokia/test/testjolokia.py
+++ b/src/collectors/jolokia/test/testjolokia.py
@@ -120,7 +120,7 @@ class TestJolokiaCollector(CollectorTestCase):
             return_value=logger_mock))
         patch_logger.start()
 
-        collector = JolokiaCollector(config, None)
+        JolokiaCollector(config, None)
 
         patch_logger.stop()
         logger_mock.error.assert_not_called()

--- a/src/collectors/kafkastat/kafkastat.py
+++ b/src/collectors/kafkastat/kafkastat.py
@@ -69,7 +69,7 @@ class KafkaCollector(diamond.collector.Collector):
 
         try:
             response = urllib2.urlopen(url)
-        except urllib2.URLError, err:
+        except urllib2.URLError as err:
             self.log.error("%s: %s", url, err)
             return None
 

--- a/src/collectors/kafkastat/test/testkafka.py
+++ b/src/collectors/kafkastat/test/testkafka.py
@@ -82,15 +82,13 @@ class TestKafkaCollector(CollectorTestCase):
     def test_get_mbeans(self, get_mock):
         get_mock.return_value = self._get_xml_fixture('serverbydomain.xml')
 
-        expected_names = set([
-            'kafka:type=kafka.BrokerAllTopicStat',
-            'kafka:type=kafka.BrokerTopicStat.mytopic',
-            'kafka:type=kafka.LogFlushStats',
-            'kafka:type=kafka.SocketServerStats',
-            'kafka:type=kafka.logs.mytopic-0',
-            'kafka:type=kafka.logs.mytopic-1',
-            'kafka:type=kafka.Log4jController',
-        ])
+        expected_names = {'kafka:type=kafka.BrokerAllTopicStat',
+                          'kafka:type=kafka.BrokerTopicStat.mytopic',
+                          'kafka:type=kafka.LogFlushStats',
+                          'kafka:type=kafka.SocketServerStats',
+                          'kafka:type=kafka.logs.mytopic-0',
+                          'kafka:type=kafka.logs.mytopic-1',
+                          'kafka:type=kafka.Log4jController'}
 
         found_beans = self.collector.get_mbeans('*')
 

--- a/src/collectors/memcached_slab/memcached_slab.py
+++ b/src/collectors/memcached_slab/memcached_slab.py
@@ -37,8 +37,7 @@ def parse_slab_stats(slab_stats):
         'total_malloced': 1048512,
     }
     """
-    stats_dict = {}
-    stats_dict['slabs'] = defaultdict(lambda: {})
+    stats_dict = {'slabs': defaultdict(lambda: {})}
 
     for line in slab_stats.splitlines():
         if line == 'END':

--- a/src/collectors/mesos/mesos.py
+++ b/src/collectors/mesos/mesos.py
@@ -198,7 +198,7 @@ class MesosCollector(diamond.collector.Collector):
         url = self._get_url(path)
         try:
             response = urllib2.urlopen(url)
-        except Exception, err:
+        except Exception as err:
             self.log.error("%s: %s", url, err)
             return False
 

--- a/src/collectors/mesos/test/testmesos.py
+++ b/src/collectors/mesos/test/testmesos.py
@@ -25,7 +25,7 @@ class TestMesosCollector(CollectorTestCase):
     def test_import(self):
         self.assertTrue(MesosCollector)
 
-    def test_import(self):
+    def test_import2(self):
         self.assertTrue(self.collector.config['path'], 'mesos')
 
     @patch.object(Collector, 'publish')

--- a/src/collectors/mesos_cgroup/mesos_cgroup.py
+++ b/src/collectors/mesos_cgroup/mesos_cgroup.py
@@ -126,7 +126,7 @@ class MesosCGroupCollector(diamond.collector.Collector):
                                        self.config['mesos_state_path'])
 
             return json.load(urllib2.urlopen(url))
-        except (urllib2.HTTPError, ValueError), err:
+        except (urllib2.HTTPError, ValueError) as err:
             self.log.error('Unable to read JSON response: %s' % err)
             return {}
 

--- a/src/collectors/mesos_cgroup/test/testmesos_cgroup.py
+++ b/src/collectors/mesos_cgroup/test/testmesos_cgroup.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 ##########################################################################
 
+from __future__ import print_function
 from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
@@ -34,7 +35,7 @@ class TestMesosCGroupCollector(CollectorTestCase):
             if url == 'http://localhost:5051/state.json':
                 return self.getFixture('state.json')
             else:
-                print url
+                print(url)
                 raise NotImplementedError()
 
         def listdir_se(directory):
@@ -47,7 +48,7 @@ class TestMesosCGroupCollector(CollectorTestCase):
             if directory in cgroup_directories:
                 return ["b0d5971e-915c-414b-aa25-0da46e64ff4e"]
             else:
-                print directory
+                print(directory)
                 raise NotImplementedError()
 
         def isdir_se(directory):
@@ -60,7 +61,7 @@ class TestMesosCGroupCollector(CollectorTestCase):
             if directory in task_directories:
                 return True
             else:
-                print directory
+                print(directory)
                 raise NotImplementedError()
 
         def open_se(path, mode='r', create=True):

--- a/src/collectors/mogilefs/test/testmogilefs.py
+++ b/src/collectors/mogilefs/test/testmogilefs.py
@@ -5,7 +5,7 @@
 from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
-from mock import Mock, call
+from mock import Mock
 from mock import patch
 
 from diamond.collector import Collector

--- a/src/collectors/mongodb/mongodb.py
+++ b/src/collectors/mongodb/mongodb.py
@@ -175,7 +175,7 @@ class MongoDBCollector(diamond.collector.Collector):
                         ssl=self.config['ssl'],
                         read_preference=ReadPreference.SECONDARY,
                     )
-            except Exception, e:
+            except Exception as e:
                 self.log.error('Couldnt connect to mongodb: %s', e)
                 continue
 
@@ -183,7 +183,7 @@ class MongoDBCollector(diamond.collector.Collector):
             if user:
                 try:
                     conn.admin.authenticate(user, passwd)
-                except Exception, e:
+                except Exception as e:
                     self.log.error(
                         'User auth given, but could not autheticate' +
                         ' with host: %s, err: %s' % (host, e))

--- a/src/collectors/mongodb/test/testmongodb.py
+++ b/src/collectors/mongodb/test/testmongodb.py
@@ -175,7 +175,7 @@ class TestMongoDBCollector(CollectorTestCase):
         # should not happen, but it did (once), so lets check it
         datapoints_per_metric = defaultdict(int)
         for c in publish_mock.call_args_list:
-            m, v = c[0][0], c[0][1]
+            m = c[0][0]
             datapoints_per_metric[m] += 1
         dupes = [m for m, n in datapoints_per_metric.iteritems() if n > 1]
         self.assertEqual(len(dupes), 0,

--- a/src/collectors/monit/monit.py
+++ b/src/collectors/monit/monit.py
@@ -55,7 +55,7 @@ class MonitCollector(diamond.collector.Collector):
                 self.config['user'], self.config['passwd'])).replace('\n', '')
             request.add_header("Authorization", "Basic %s" % base64string)
             response = urllib2.urlopen(request)
-        except urllib2.HTTPError, err:
+        except urllib2.HTTPError as err:
             self.log.error("%s: %s", err, url)
             return
 

--- a/src/collectors/mysqlstat/mysql55.py
+++ b/src/collectors/mysqlstat/mysql55.py
@@ -133,7 +133,7 @@ class MySQLPerfCollector(diamond.collector.Collector):
 
         try:
             self.db = MySQLdb.connect(**params)
-        except MySQLError, e:
+        except MySQLError as e:
             self.log.error('MySQLPerfCollector couldnt connect to database %s',
                            e)
             return {}

--- a/src/collectors/mysqlstat/mysql55.py
+++ b/src/collectors/mysqlstat/mysql55.py
@@ -227,9 +227,8 @@ class MySQLPerfCollector(diamond.collector.Collector):
             if not matches:
                 continue
 
-            params = {}
+            params = {'host': matches.group(3)}
 
-            params['host'] = matches.group(3)
             try:
                 params['port'] = int(matches.group(4))
             except ValueError:

--- a/src/collectors/mysqlstat/mysqlstat.py
+++ b/src/collectors/mysqlstat/mysqlstat.py
@@ -452,9 +452,8 @@ class MySQLCollector(diamond.collector.Collector):
                     host)
                 continue
 
-            params = {}
+            params = {'host': matches.group(3)}
 
-            params['host'] = matches.group(3)
             try:
                 params['port'] = int(matches.group(4))
             except ValueError:

--- a/src/collectors/mysqlstat/mysqlstat.py
+++ b/src/collectors/mysqlstat/mysqlstat.py
@@ -296,7 +296,7 @@ class MySQLCollector(diamond.collector.Collector):
         try:
             cursor.execute(query)
             return cursor.fetchall()
-        except MySQLError, e:
+        except MySQLError as e:
             self.log.error('MySQLCollector could not get db stats', e)
             return ()
 
@@ -304,7 +304,7 @@ class MySQLCollector(diamond.collector.Collector):
         try:
             self.db = MySQLdb.connect(**params)
             self.log.debug('MySQLCollector: Connected to database.')
-        except MySQLError, e:
+        except MySQLError as e:
             self.log.error('MySQLCollector couldnt connect to database %s', e)
             return False
         return True
@@ -403,7 +403,7 @@ class MySQLCollector(diamond.collector.Collector):
                 for key in todo:
                     self.log.debug("MySQLCollector: %s regexp not matched " +
                                    "in innodb status", key)
-            except Exception, innodb_status_error:
+            except Exception as innodb_status_error:
                 self.log.error('MySQLCollector: Couldnt get engine innodb ' +
                                'status, check user permissions: %s',
                                innodb_status_error)
@@ -471,7 +471,7 @@ class MySQLCollector(diamond.collector.Collector):
 
             try:
                 metrics = self.get_stats(params=params)
-            except Exception, e:
+            except Exception as e:
                 try:
                     self.disconnect()
                 except MySQLdb.ProgrammingError:

--- a/src/collectors/nagiosperfdata/nagiosperfdata.py
+++ b/src/collectors/nagiosperfdata/nagiosperfdata.py
@@ -201,7 +201,7 @@ class NagiosPerfdataCollector(diamond.collector.Collector):
                 self._process_line(line)
 
             os.remove(path)
-        except IOError, ex:
+        except IOError as ex:
             self.log.error("Could not open file `{path}': {error}".format(
                 path=path, error=ex.strerror))
 

--- a/src/collectors/netapp/netapp.py
+++ b/src/collectors/netapp/netapp.py
@@ -33,6 +33,7 @@ https://communities.netapp.com/docs/DOC-1044
 
 """
 
+from __future__ import print_function
 import sys
 import time
 import re
@@ -319,8 +320,8 @@ class NetAppCollector(diamond.collector.Collector):
                 res = server.invoke_elem(query)
 
                 if(res.results_status() == "failed"):
-                    print "Connection to filer %s failed; %s" % (
-                        device, res.results_reason())
+                    print("Connection to filer %s failed; %s" % (
+                        device, res.results_reason()))
                     return
 
                 num_records = res.child_get_int("records")

--- a/src/collectors/netapp/netappDisk.py
+++ b/src/collectors/netapp/netappDisk.py
@@ -18,6 +18,7 @@
 
 """
 
+from __future__ import print_function
 import diamond.collector
 import time
 from diamond.metric import Metric
@@ -273,7 +274,7 @@ class netappDiskCol(object):
             self.log.error(
                 'While using netapp API failed to retrieve '
                 'disk-list-info for netapp filer %s' % self.device)
-            print netapp_data.sprintf()
+            print(netapp_data.sprintf())
             return
         netapp_xml = \
             ET.fromstring(netapp_data.sprintf()).find(sub_element)

--- a/src/collectors/netstat/netstat.py
+++ b/src/collectors/netstat/netstat.py
@@ -13,10 +13,6 @@ Based on Ricardo Pascal's "netstat in <100 lines of code"
 """
 
 import diamond.collector
-import pwd
-import os
-import re
-import glob
 
 
 class NetstatCollector(diamond.collector.Collector):

--- a/src/collectors/netstat/netstat.py
+++ b/src/collectors/netstat/netstat.py
@@ -64,7 +64,7 @@ class NetstatCollector(diamond.collector.Collector):
 
     @staticmethod
     def _load():
-        ''' Read the table of tcp connections & remove header  '''
+        """ Read the table of tcp connections & remove header  """
         with open(NetstatCollector.PROC_TCP, 'r') as f:
             content = f.readlines()
             content.pop(0)

--- a/src/collectors/netstat/test/testnetstat.py
+++ b/src/collectors/netstat/test/testnetstat.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 ################################################################################
 
+from __future__ import print_function
 from test import CollectorTestCase
 from test import get_collector_config
 from test import unittest
@@ -32,7 +33,7 @@ class TestNetstatCollector(CollectorTestCase):
         self.setDocExample(collector=self.collector.__class__.__name__,
                            metrics=metrics,
                            defaultpath=self.collector.config['path'])
-        print publish_mock
+        print(publish_mock)
         self.assertPublishedMany(publish_mock, metrics)
 
 ################################################################################

--- a/src/collectors/nginx/nginx.py
+++ b/src/collectors/nginx/nginx.py
@@ -229,7 +229,7 @@ class NginxCollector(diamond.collector.Collector):
             else:
                 self.collect_nginx(handle)
 
-        except IOError, e:
+        except IOError:
             self.log.error("Unable to open %s" % url)
-        except Exception, e:
+        except Exception as e:
             self.log.error("Unknown error opening url: %s", e)

--- a/src/collectors/ntp/ntp.py
+++ b/src/collectors/ntp/ntp.py
@@ -22,10 +22,7 @@ $
 
 """
 
-import subprocess
-
 import diamond.collector
-from diamond.collector import str_to_bool
 from diamond import convertor
 
 

--- a/src/collectors/ntp/ntp.py
+++ b/src/collectors/ntp/ntp.py
@@ -58,8 +58,7 @@ class NtpCollector(diamond.collector.ProcessCollector):
     def get_ntpdate_stats(self):
         output = self.run_command(['-q', self.config['ntp_pool']])
 
-        data = {}
-        data['server.count'] = {'val': 0, 'precision': 0}
+        data = {'server.count': {'val': 0, 'precision': 0}}
 
         for line in output[0].splitlines():
             # Only care about best choice not all servers

--- a/src/collectors/openldap/openldap.py
+++ b/src/collectors/openldap/openldap.py
@@ -160,7 +160,7 @@ class OpenLDAPCollector(diamond.collector.Collector):
             datapoints = self.get_datapoints(ldap_url,
                                              self.config['username'],
                                              self.config['password'])
-        except Exception, e:
+        except Exception as e:
             self.log.error('Unable to query %s: %s' % (ldap_url, e))
             return {}
 

--- a/src/collectors/openvpn/openvpn.py
+++ b/src/collectors/openvpn/openvpn.py
@@ -165,7 +165,7 @@ class OpenVPNCollector(diamond.collector.Collector):
             # Bye
             server.close()
 
-        except socket.error, e:
+        except socket.error as e:
             self.log.error('OpenVPN management connection error: %s', e)
             return
 

--- a/src/collectors/ossec/ossec.py
+++ b/src/collectors/ossec/ossec.py
@@ -54,7 +54,7 @@ class OssecCollector(diamond.collector.Collector):
         try:
             p = subprocess.Popen(command, stdout=subprocess.PIPE)
             res = p.communicate()[0]
-        except Exception, e:
+        except Exception as e:
             self.log.error('Unable to exec cmd: %s, because %s'
                            % (' '.join(command), str(e)))
             return

--- a/src/collectors/pgq/pgq.py
+++ b/src/collectors/pgq/pgq.py
@@ -60,7 +60,7 @@ class PgQCollector(diamond.collector.Collector):
             self._collect_for_instance(instance, connection)
 
     def _collect_for_instance(self, instance, connection):
-        "Collects metrics for a named connection."
+        """Collects metrics for a named connection."""
         with connection.cursor() as cursor:
             for queue, metrics in self.get_queue_info(instance, cursor):
                 for name, metric in metrics.items():
@@ -82,7 +82,7 @@ class PgQCollector(diamond.collector.Collector):
     """
 
     def get_queue_info(self, instance, cursor):
-        "Collects metrics for all queues on the connected database."
+        """Collects metrics for all queues on the connected database."""
         cursor.execute(self.QUEUE_INFO_STATEMENT)
         for queue_name, ticker_lag, ev_per_sec in cursor:
             yield queue_name, {
@@ -101,7 +101,7 @@ class PgQCollector(diamond.collector.Collector):
     """
 
     def get_consumer_info(self, instance, cursor):
-        "Collects metrics for all consumers on the connected database."
+        """Collects metrics for all consumers on the connected database."""
         cursor.execute(self.CONSUMER_INFO_STATEMENT)
         for queue_name, consumer_name, lag, pending_events, last_seen in cursor:
             yield queue_name, consumer_name, {

--- a/src/collectors/phpfpm/phpfpm.py
+++ b/src/collectors/phpfpm/phpfpm.py
@@ -75,13 +75,13 @@ class PhpFpmCollector(diamond.collector.Collector):
             response = urllib2.urlopen("http://%s:%s/%s?json" % (
                 self.config['host'], int(self.config['port']),
                 self.config['uri']))
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldnt connect to php-fpm status page: %s', e)
             return {}
 
         try:
             j = json.loads(response.read())
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldnt parse json: %s', e)
             return {}
 

--- a/src/collectors/postfix/postfix.py
+++ b/src/collectors/postfix/postfix.py
@@ -14,7 +14,6 @@ get realtime cumulative stats.
 """
 
 import socket
-import sys
 
 try:
     import json

--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -170,7 +170,7 @@ class PostgresqlCollector(diamond.collector.Collector):
 
         try:
             conn = psycopg2.connect(**conn_args)
-        except Exception, e:
+        except Exception as e:
             self.log.error(e)
             raise e
 

--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -181,7 +181,7 @@ class ProcessResourcesCollector(diamond.collector.Collector):
                     uptime = time.time() - get_value(process, 'create_time')
                     pi.update({'uptime': uptime})
                     self.save_process_info(pg_name, pi)
-        except psutil.NoSuchProcess, e:
+        except psutil.NoSuchProcess as e:
             self.log.info("Process exited while trying to get info: %s", e)
 
     def collect(self):

--- a/src/collectors/puppetdashboard/puppetdashboard.py
+++ b/src/collectors/puppetdashboard/puppetdashboard.py
@@ -42,7 +42,7 @@ class PuppetDashboardCollector(diamond.collector.Collector):
         try:
             response = urllib2.urlopen("http://%s:%s/" % (
                 self.config['host'], int(self.config['port'])))
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldnt connect to puppet-dashboard: %s', e)
             return {}
 
@@ -59,5 +59,5 @@ class PuppetDashboardCollector(diamond.collector.Collector):
                 results = r.groupdict()
 
                 self.publish(results['key'], results['count'])
-            except Exception, e:
+            except Exception as e:
                 self.log.error('Couldnt parse the output: %s', e)

--- a/src/collectors/puppetdb/puppetdb.py
+++ b/src/collectors/puppetdb/puppetdb.py
@@ -91,7 +91,7 @@ class PuppetDBCollector(diamond.collector.Collector):
             url = "http://%s:%s/%s" % (
                 self.config['host'], int(self.config['port']), url)
             response = urllib2.urlopen(url)
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldn\'t connect to puppetdb: %s -> %s', url, e)
             return {}
         return json.load(response)

--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -164,7 +164,7 @@ class RabbitMQCollector(diamond.collector.Collector):
             node_name = client.get_overview()['node']
             node_data = client.get_node(node_name)
             for metric in health_metrics:
-                self.publish('health.{0}'.format(metric), node_data[metric])
+                self.publish('health.{}'.format(metric), node_data[metric])
             if self.config['cluster']:
                 self.publish('cluster.partitions',
                              len(node_data['partitions']))
@@ -270,7 +270,7 @@ class RabbitMQCollector(diamond.collector.Collector):
                             queue_name = queue_name.replace(
                                 '/', self.config['replace_slash'])
 
-                        name = '{0}.{1}'.format(prefix, queue_name)
+                        name = '{}.{}'.format(prefix, queue_name)
 
                         self._publish_metrics(name, [], key, queue)
 
@@ -291,7 +291,7 @@ class RabbitMQCollector(diamond.collector.Collector):
         elif isinstance(value, (float, int, long)):
             joined_keys = '.'.join(keys)
             if name:
-                publish_key = '{0}.{1}'.format(name, joined_keys)
+                publish_key = '{}.{}'.format(name, joined_keys)
             else:
                 publish_key = joined_keys
             if isinstance(value, bool):

--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -66,7 +66,7 @@ class RabbitMQClient(object):
         try:
             queue = self.do_call(path)
             return queue or None
-        except Exception, e:
+        except Exception as e:
             self.log.error('Error querying queue %s/%s: %s' % (
                 vhost, queue_name, e
             ))
@@ -80,7 +80,7 @@ class RabbitMQClient(object):
         try:
             queues = self.do_call(path)
             return queues or []
-        except Exception, e:
+        except Exception as e:
             self.log.error('Error querying queues %s: %s' % (
                 vhost, e
             ))

--- a/src/collectors/redisstat/redisstat.py
+++ b/src/collectors/redisstat/redisstat.py
@@ -222,7 +222,7 @@ class RedisCollector(diamond.collector.Collector):
                               unix_socket_path=unix_socket)
             cli.ping()
             return cli
-        except Exception, ex:
+        except Exception as ex:
             self.log.error("RedisCollector: failed to connect to %s:%i. %s.",
                            unix_socket or host, port, ex)
 

--- a/src/collectors/resqueweb/resqueweb.py
+++ b/src/collectors/resqueweb/resqueweb.py
@@ -37,7 +37,7 @@ class ResqueWebCollector(diamond.collector.Collector):
         try:
             response = urllib2.urlopen("http://%s:%s/stats.txt" % (
                 self.config['host'], int(self.config['port'])))
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldnt connect to resque-web: %s', e)
             return {}
 
@@ -59,5 +59,5 @@ class ResqueWebCollector(diamond.collector.Collector):
                 else:
                     self.publish("queue.%s.current" % queue, count)
 
-            except Exception, e:
+            except Exception as e:
                 self.log.error('Couldnt parse the queue: %s', e)

--- a/src/collectors/sidekiq/sidekiq.py
+++ b/src/collectors/sidekiq/sidekiq.py
@@ -68,7 +68,6 @@ class SidekiqCollector(diamond.collector.Collector):
 
     def get_redis_client(self):
         """
-        :param db: Redis database index
         :return: Redis client
         """
         host = self.config['host']

--- a/src/collectors/sidekiqweb/sidekiqweb.py
+++ b/src/collectors/sidekiqweb/sidekiqweb.py
@@ -44,13 +44,13 @@ class SidekiqWebCollector(diamond.collector.Collector):
         try:
             response = urllib2.urlopen("http://%s:%s/dashboard/stats" % (
                 self.config['host'], int(self.config['port'])))
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldnt connect to sidekiq-web: %s', e)
             return {}
 
         try:
             j = json.loads(response.read())
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldnt parse json: %s', e)
             return {}
 

--- a/src/collectors/snmp/snmp.py
+++ b/src/collectors/snmp/snmp.py
@@ -88,7 +88,7 @@ class SNMPCollector(diamond.collector.Collector):
 
         # Assemble SNMP Auth Data
         snmpAuthData = cmdgen.CommunityData(
-            'agent-{0}'.format(community),
+            'agent-{}'.format(community),
             community)
 
         # Assemble SNMP Transport Data
@@ -124,7 +124,7 @@ class SNMPCollector(diamond.collector.Collector):
 
         # Assemble SNMP Auth Data
         snmpAuthData = cmdgen.CommunityData(
-            'agent-{0}'.format(community),
+            'agent-{}'.format(community),
             community)
 
         # Assemble SNMP Transport Data

--- a/src/collectors/snmpraw/snmpraw.py
+++ b/src/collectors/snmpraw/snmpraw.py
@@ -98,7 +98,7 @@ class SNMPRawCollector(parent_SNMPCollector):
     def _skip(self, device, oid, reason=None):
         self.skip_list.append((device, oid))
         if reason is not None:
-            self.log.warn('Muted \'{0}\' on \'{1}\', because: {2}'.format(
+            self.log.warn('Muted \'{}\' on \'{}\', because: {}'.format(
                 oid, device, reason))
 
     def _get_value_walk(self, device, oid, host, port, community):
@@ -108,14 +108,14 @@ class SNMPRawCollector(parent_SNMPCollector):
             self._skip(device, oid, 'device down (#2)')
             return
 
-        self.log.debug('Data received from WALK \'{0}\': [{1}]'.format(
+        self.log.debug('Data received from WALK \'{}\': [{}]'.format(
             device, data))
 
         if len(data) != 1:
             self._skip(
                 device,
                 oid,
-                'unexpected response, data has {0} entries'.format(
+                'unexpected response, data has {} entries'.format(
                     len(data)))
             return
 
@@ -130,7 +130,7 @@ class SNMPRawCollector(parent_SNMPCollector):
             self._skip(device, oid, 'device down (#1)')
             return
 
-        self.log.debug('Data received from GET \'{0}\': [{1}]'.format(
+        self.log.debug('Data received from GET \'{}\': [{}]'.format(
             device, data))
 
         if len(data) == 0:
@@ -158,7 +158,7 @@ class SNMPRawCollector(parent_SNMPCollector):
         Collect SNMP interface data from device
         """
         self.log.debug(
-            'Collecting raw SNMP statistics from device \'{0}\''.format(device))
+            'Collecting raw SNMP statistics from device \'{}\''.format(device))
 
         dev_config = self.config['devices'][device]
         if 'oids' in dev_config:
@@ -166,7 +166,7 @@ class SNMPRawCollector(parent_SNMPCollector):
 
                 if (device, oid) in self.skip_list:
                     self.log.debug(
-                        'Skipping OID \'{0}\' ({1}) on device \'{2}\''.format(
+                        'Skipping OID \'{}\' ({}) on device \'{}\''.format(
                             oid, metricName, device))
                     continue
 
@@ -176,7 +176,7 @@ class SNMPRawCollector(parent_SNMPCollector):
                     continue
 
                 self.log.debug(
-                    '\'{0}\' ({1}) on device \'{2}\' - value=[{3}]'.format(
+                    '\'{}\' ({}) on device \'{}\' - value=[{}]'.format(
                         oid, metricName, device, value))
 
                 path = '.'.join([self.config['path_prefix'], device,

--- a/src/collectors/solr/solr.py
+++ b/src/collectors/solr/solr.py
@@ -76,7 +76,7 @@ class SolrCollector(diamond.collector.Collector):
             self.config['host'], int(self.config['port']), path)
         try:
             response = urllib2.urlopen(url)
-        except Exception, err:
+        except Exception as err:
             self.log.error("%s: %s", url, err)
             return False
 

--- a/src/collectors/solr/solr.py
+++ b/src/collectors/solr/solr.py
@@ -104,12 +104,12 @@ class SolrCollector(diamond.collector.Collector):
         metrics = {}
         for core in cores:
             if core:
-                path = "{0}.".format(core)
+                path = "{}.".format(core)
             else:
                 path = ""
 
             ping_url = posixpath.normpath(
-                "/solr/{0}/admin/ping?wt=json".format(core))
+                "/solr/{}/admin/ping?wt=json".format(core))
 
             if 'response' in self.config['stats']:
                 result = self._get(ping_url)
@@ -117,14 +117,14 @@ class SolrCollector(diamond.collector.Collector):
                     continue
 
                 metrics.update({
-                    "{0}response.QueryTime".format(path):
+                    "{}response.QueryTime".format(path):
                     result["responseHeader"]["QTime"],
-                    "{0}response.Status".format(path):
+                    "{}response.Status".format(path):
                     result["responseHeader"]["status"],
                 })
 
             stats_url = posixpath.normpath(
-                "/solr/{0}/admin/mbeans?stats=true&wt=json".format(core))
+                "/solr/{}/admin/mbeans?stats=true&wt=json".format(core))
 
             result = self._get(stats_url)
             if not result:
@@ -137,7 +137,7 @@ class SolrCollector(diamond.collector.Collector):
                 core_searcher = stats["CORE"]["searcher"]["stats"]
 
                 metrics.update([
-                    ("{0}core.{1}".format(path, key),
+                    ("{}core.{}".format(path, key),
                      core_searcher[key])
                     for key in ("maxDoc", "numDocs", "warmupTime")
                 ])
@@ -147,14 +147,14 @@ class SolrCollector(diamond.collector.Collector):
                 update = stats["QUERYHANDLER"]["/update"]["stats"]
 
                 metrics.update([
-                    ("{0}queryhandler.standard.{1}".format(path, key),
+                    ("{}queryhandler.standard.{}".format(path, key),
                      standard[key])
                     for key in ("requests", "errors", "timeouts", "totalTime",
                                 "avgTimePerRequest", "avgRequestsPerSecond")
                 ])
 
                 metrics.update([
-                    ("{0}queryhandler.update.{1}".format(path, key),
+                    ("{}queryhandler.update.{}".format(path, key),
                      update[key])
                     for key in ("requests", "errors", "timeouts", "totalTime",
                                 "avgTimePerRequest", "avgRequestsPerSecond")
@@ -166,7 +166,7 @@ class SolrCollector(diamond.collector.Collector):
                     stats["UPDATEHANDLER"]["updateHandler"]["stats"]
 
                 metrics.update([
-                    ("{0}updatehandler.{1}".format(path, key),
+                    ("{}updatehandler.{}".format(path, key),
                      updatehandler[key])
                     for key in (
                         "commits", "autocommits", "optimizes",
@@ -178,7 +178,7 @@ class SolrCollector(diamond.collector.Collector):
                 cache = stats["CACHE"]
 
                 metrics.update([
-                    ("{0}cache.{1}.{2}".format(path, cache_type, key),
+                    ("{}cache.{}.{}".format(path, cache_type, key),
                      self._try_convert(cache[cache_type]['stats'][key]))
                     for cache_type in (
                         'fieldValueCache', 'filterCache',
@@ -193,7 +193,7 @@ class SolrCollector(diamond.collector.Collector):
 
             if 'jvm' in self.config['stats']:
                 system_url = posixpath.normpath(
-                    "/solr/{0}/admin/system?stats=true&wt=json".format(core))
+                    "/solr/{}/admin/system?stats=true&wt=json".format(core))
 
                 result = self._get(system_url)
                 if not result:
@@ -201,7 +201,7 @@ class SolrCollector(diamond.collector.Collector):
 
                 mem = result['jvm']['memory']
                 metrics.update([
-                    ('{0}jvm.mem.{1}'.format(path, key),
+                    ('{}jvm.mem.{}'.format(path, key),
                      self._try_convert(mem[key].split()[0]))
                     for key in ('free', 'total', 'max', 'used')
                 ])

--- a/src/collectors/squid/squid.py
+++ b/src/collectors/squid/squid.py
@@ -79,7 +79,7 @@ class SquidCollector(diamond.collector.Collector):
                 if not data:
                     break
                 fulldata = fulldata + data
-        except Exception, e:
+        except Exception as e:
             self.log.error('Couldnt connect to squid: %s', e)
             return None
         squid_sock.close()

--- a/src/collectors/supervisord/supervisord.py
+++ b/src/collectors/supervisord/supervisord.py
@@ -60,7 +60,7 @@ class SupervisordCollector(diamond.collector.Collector):
         server = None
         protocol = self.config['xmlrpc_server_protocol']
         path = self.config['xmlrpc_server_path']
-        uri = '{0}://{1}'.format(protocol, path)
+        uri = '{}://{}'.format(protocol, path)
 
         self.log.debug(
             'Attempting to connect to XML-RPC server "%s"', uri)

--- a/src/collectors/tokumx/tokumx.py
+++ b/src/collectors/tokumx/tokumx.py
@@ -125,7 +125,7 @@ class TokuMXCollector(diamond.collector.Collector):
                         network_timeout=self.config['network_timeout'],
                         read_preference=ReadPreference.SECONDARY,
                     )
-            except Exception, e:
+            except Exception as e:
                 self.log.error('Couldnt connect to mongodb: %s', e)
                 continue
 
@@ -133,7 +133,7 @@ class TokuMXCollector(diamond.collector.Collector):
             if user:
                 try:
                     conn.admin.authenticate(user, passwd)
-                except Exception, e:
+                except Exception as e:
                     self.log.error(
                         'User auth given, but could not autheticate' +
                         ' with host: %s, err: %s' % (host, e))

--- a/src/collectors/unbound/unbound.py
+++ b/src/collectors/unbound/unbound.py
@@ -54,7 +54,7 @@ class UnboundCollector(diamond.collector.ProcessCollector):
                 histogram[intv_name] = raw_histogram[intv]
             elif intv == 1.0:
                 histogram['512ms+'] = raw_histogram[intv]
-            elif intv > 1.0 and intv <= 64.0:
+            elif 1.0 < intv <= 64.0:
                 # Convert upper limit into lower limit seconds
                 intv_name = ''.join([str(int(intv / 2)), 's+'])
                 histogram[intv_name] = raw_histogram[intv]

--- a/src/collectors/uptime/uptime.py
+++ b/src/collectors/uptime/uptime.py
@@ -42,7 +42,7 @@ class UptimeCollector(Collector):
             fd.close()
             v = float(uptime.split()[0].strip())
             return convertor.time.convert(v, 's', self.config['metric_name'])
-        except Exception, e:
+        except Exception as e:
             self.log.error('Unable to read uptime from %s: %s' % (self.PROC,
                                                                   e))
             return None

--- a/src/collectors/users/users.py
+++ b/src/collectors/users/users.py
@@ -51,8 +51,7 @@ class UsersCollector(diamond.collector.Collector):
             self.log.error('Unable to import either pyutmp or python-utmp')
             return False
 
-        metrics = {}
-        metrics['total'] = 0
+        metrics = {'total': 0}
 
         if UtmpFile:
             for utmp in UtmpFile(path=self.config['utmp']):

--- a/src/collectors/userscripts/test/testuserscripts.py
+++ b/src/collectors/userscripts/test/testuserscripts.py
@@ -3,7 +3,6 @@
 ##########################################################################
 
 import os
-import sys
 
 from test import CollectorTestCase
 from test import get_collector_config
@@ -18,13 +17,7 @@ from userscripts import UserScriptsCollector
 
 
 def run_only_if_kitchen_is_available(func):
-    if sys.version_info < (2, 7):
-        try:
-            from kitchen.pycompat27 import subprocess
-        except ImportError:
-            subprocess = None
-    else:
-        import subprocess
+    import subprocess
     pred = lambda: subprocess is not None
     return run_only(func, pred)
 

--- a/src/collectors/userscripts/userscripts.py
+++ b/src/collectors/userscripts/userscripts.py
@@ -71,7 +71,7 @@ class UserScriptsCollector(diamond.collector.Collector):
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE)
                 (out, err) = proc.communicate()
-            except subprocess.CalledProcessError, e:
+            except subprocess.CalledProcessError as e:
                 self.log.error("%s error launching: %s; skipping" %
                                (absolutescriptpath, e))
                 continue

--- a/src/collectors/websitemonitor/websitemonitor.py
+++ b/src/collectors/websitemonitor/websitemonitor.py
@@ -60,7 +60,7 @@ class WebsiteMonitorCollector(diamond.collector.Collector):
             self.publish('response_time.%s' % (resp.code), rt,
                          metric_type='COUNTER')
         # urllib2 will puke on non HTTP 200/OK URLs
-        except urllib2.URLError, e:
+        except urllib2.URLError as e:
             if e.code != 200:
                 # time in seconds since epoch as a floating number
                 end_time = time.time()
@@ -71,8 +71,8 @@ class WebsiteMonitorCollector(diamond.collector.Collector):
                 self.publish('response_time.%s' % (e.code), rt,
                              metric_type='COUNTER')
 
-        except IOError, e:
+        except IOError as e:
             self.log.error('Unable to open %s' % (self.config['URL']))
 
-        except Exception, e:
+        except Exception as e:
             self.log.error("Unknown error opening url: %s", e)

--- a/src/collectors/xfs/xfs.py
+++ b/src/collectors/xfs/xfs.py
@@ -10,7 +10,6 @@ The XFSCollector collects XFS metrics using /proc/fs/xfs/stat.
 """
 
 import diamond.collector
-import sys
 
 
 class XFSCollector(diamond.collector.Collector):

--- a/src/diamond/gmetric.py
+++ b/src/diamond/gmetric.py
@@ -37,6 +37,7 @@
 #   Made it work with the Ganglia 3.1 data format
 
 
+from __future__ import print_function
 from xdrlib import Packer, Unpacker
 import socket
 
@@ -93,7 +94,7 @@ class Gmetric:
                                              TMAX,
                                              DMAX,
                                              GROUP)
-        # print msg
+        # print(msg)
 
         self.socket.sendto(meta_msg, self.hostport)
         self.socket.sendto(data_msg, self.hostport)

--- a/src/diamond/handler/cloudwatch.py
+++ b/src/diamond/handler/cloudwatch.py
@@ -254,10 +254,10 @@ class cloudwatchHandler(Handler):
                 rule['namespace'],
                 str(metric.value),
                 str(dimensions))
-        except AttributeError, e:
+        except AttributeError as e:
             self.log.error(
                 "CloudWatch: Failed publishing - %s ", str(e))
-        except Exception, e:  # Rough connection re-try logic.
+        except Exception as e:  # Rough connection re-try logic.
             self.log.error(
                 "CloudWatch: Failed publishing - %s\n%s ",
                 str(e),

--- a/src/diamond/handler/graphite.py
+++ b/src/diamond/handler/graphite.py
@@ -202,7 +202,7 @@ class GraphiteHandler(Handler):
             connection_struct = (self.host, self.port)
             try:
                 addrinfo = socket.getaddrinfo(self.host, self.port, 0, stream)
-            except socket.gaierror, ex:
+            except socket.gaierror as ex:
                 self.log.error("GraphiteHandler: Error looking up graphite host"
                                " '%s' - %s",
                                self.host, ex)
@@ -242,7 +242,7 @@ class GraphiteHandler(Handler):
                            "graphite server %s:%d.",
                            self.host, self.port)
             self.last_connect_timestamp = time.time()
-        except Exception, ex:
+        except Exception as ex:
             # Log Error
             self._throttle_error("GraphiteHandler: Failed to connect to "
                                  "%s:%i. %s.", self.host, self.port, ex)

--- a/src/diamond/handler/influxdbHandler.py
+++ b/src/diamond/handler/influxdbHandler.py
@@ -207,7 +207,7 @@ class InfluxdbHandler(Handler):
             self.log.debug("InfluxdbHandler: Established connection to "
                            "%s:%d/%s.",
                            self.hostname, self.port, self.database)
-        except Exception, ex:
+        except Exception as ex:
             # Log Error
             self._throttle_error("InfluxdbHandler: Failed to connect to "
                                  "%s:%d/%s. %s",

--- a/src/diamond/handler/logentries_diamond.py
+++ b/src/diamond/handler/logentries_diamond.py
@@ -79,5 +79,5 @@ class LogentriesDiamondHandler(Handler):
                                   self.log_token, msg)
             try:
                 urllib2.urlopen(req)
-            except urllib2.URLError, e:
+            except urllib2.URLError as e:
                 logging.error("Can't send log message to Logentries %s", e)

--- a/src/diamond/handler/mysql.py
+++ b/src/diamond/handler/mysql.py
@@ -83,7 +83,7 @@ class MySQLHandler(Handler):
                            (data[0], data[2], data[1]))
             cursor.close()
             self.conn.commit()
-        except BaseException, e:
+        except BaseException as e:
             # Log Error
             self.log.error("MySQLHandler: Failed sending data. %s.", e)
             # Attempt to restablish connection

--- a/src/diamond/handler/rabbitmq_pubsub.py
+++ b/src/diamond/handler/rabbitmq_pubsub.py
@@ -156,7 +156,7 @@ class rmqHandler (Handler):
                     durable=self.rmq_durable)
                 # Reset reconnect_interval after a successful connection
                 self.reconnect_interval = 1
-            except Exception, exception:
+            except Exception as exception:
                 self.log.debug("Caught exception in _bind: %s", exception)
                 if rmq_server in self.connections.keys():
                     self._unbind(rmq_server)
@@ -200,7 +200,7 @@ class rmqHandler (Handler):
                 channel = self.channels[rmq_server]
                 channel.basic_publish(exchange=self.rmq_exchange,
                                       routing_key='', body="%s" % metric)
-            except Exception, exception:
+            except Exception as exception:
                 self.log.error(
                     "Failed publishing to %s, attempting reconnect",
                     rmq_server)

--- a/src/diamond/handler/riemann.py
+++ b/src/diamond/handler/riemann.py
@@ -87,7 +87,7 @@ class RiemannHandler(Handler):
         event = self._metric_to_riemann_event(metric)
         try:
             self.client.send_event(event)
-        except Exception, e:
+        except Exception as e:
             self.log.error(
                 "RiemannHandler: Error sending event to Riemann: %s", e)
 

--- a/src/diamond/handler/sentry.py
+++ b/src/diamond/handler/sentry.py
@@ -333,7 +333,7 @@ class SentryHandler(Handler):
         # init rule
         try:
             return Rule(**kwargs)
-        except InvalidRule, err:
+        except InvalidRule as err:
             self.log.error(str(err))
 
     def configure_sentry_errors(self):

--- a/src/diamond/handler/statsite.py
+++ b/src/diamond/handler/statsite.py
@@ -148,7 +148,7 @@ class StatsiteHandler(Handler):
                 self.socket.sendall(data)
                 # Done
                 break
-            except socket.error, e:
+            except socket.error as e:
                 # Log Error
                 self.log.error("StatsiteHandler: Failed sending data. %s.", e)
                 # Attempt to restablish connection
@@ -183,7 +183,7 @@ class StatsiteHandler(Handler):
             # Log
             self.log.debug("Established connection to statsite server %s:%d",
                            self.host, self.port)
-        except Exception, ex:
+        except Exception as ex:
             # Log Error
             self.log.error("StatsiteHandler: Failed to connect to %s:%i. %s",
                            self.host, self.port, ex)

--- a/src/diamond/handler/test/testgraphitehandler.py
+++ b/src/diamond/handler/test/testgraphitehandler.py
@@ -230,7 +230,7 @@ class TestGraphiteHandler(unittest.TestCase):
         send_mock = Mock()
         patch_send = patch.object(handler, '_send_data', send_mock)
         check_mock = Mock()
-        patch_check = patch.object(handler, '_time_to_reconnect', check_mock)
+        patch.object(handler, '_time_to_reconnect', check_mock)
 
         patch_sock.start()
         patch_send.start()

--- a/src/diamond/handler/test/testriemann.py
+++ b/src/diamond/handler/test/testriemann.py
@@ -6,7 +6,6 @@ from test import unittest
 from test import run_only
 from mock import Mock
 from mock import patch
-from mock import call
 import configobj
 
 import diamond.handler.riemann as mod

--- a/src/diamond/handler/test/testtsdb.py
+++ b/src/diamond/handler/test/testtsdb.py
@@ -3,7 +3,7 @@
 ##########################################################################
 
 from test import unittest
-from mock import patch, Mock
+from mock import patch
 from diamond.metric import Metric
 import urllib2
 import configobj

--- a/src/diamond/handler/test/testtsdb.py
+++ b/src/diamond/handler/test/testtsdb.py
@@ -184,7 +184,7 @@ class TestTSDBdHandler(unittest.TestCase):
         header = {'Content-Type': 'application/json'}
         mock_urlopen.assert_called_with(self.url, body, header)
 
-    def test_cpu_metrics_taghandling_default(self, mock_urlopen, mock_request):
+    def test_cpu_metrics_taghandling_default2(self, mock_urlopen, mock_request):
         """
         aggregate default
         """

--- a/src/diamond/handler/tsdb.py
+++ b/src/diamond/handler/tsdb.py
@@ -242,10 +242,10 @@ class TSDBHandler(Handler):
                     # Transaction should be finished
                     self.log.debug(response.getcode())
                     success = True
-            except urllib2.HTTPError, e:
+            except urllib2.HTTPError as e:
                 self.log.error("HTTP Error Code: "+str(e.code))
                 self.log.error("Message : "+str(e.reason))
-            except urllib2.URLError, e:
+            except urllib2.URLError as e:
                 self.log.error("Connection Error: "+str(e.reason))
             finally:
                 retry += 1

--- a/src/diamond/handler/tsdb.py
+++ b/src/diamond/handler/tsdb.py
@@ -123,8 +123,7 @@ class TSDBHandler(Handler):
             self.tags.append([key, value])
 
         # headers
-        self.httpheader = {}
-        self.httpheader["Content-Type"] = "application/json"
+        self.httpheader = {"Content-Type": "application/json"}
         # Authorization
         if self.user != "":
             self.httpheader["Authorization"] = "Basic " +\
@@ -191,10 +190,8 @@ class TSDBHandler(Handler):
         """
         Process a metric by sending it to TSDB
         """
-        entry = {}
-        entry['timestamp'] = metric.timestamp
-        entry['value'] = metric.value
-        entry["tags"] = {}
+        entry = {'timestamp': metric.timestamp, 'value': metric.value,
+                 "tags": {}}
         entry["tags"]["hostname"] = metric.host
 
         if self.cleanMetrics:
@@ -362,14 +359,12 @@ class MetricWrapper(Metric):
                 self.path = self.path.replace("."+team+".", ".")
                 self.path = self.path.replace("."+channel+".", ".")
 
-    handlers = {}
-    handlers['cpu'] = processCpuMetric
-    handlers['haproxy'] = processHaProxyMetric
-    handlers['mattermost'] = processMattermostMetric
-    handlers['diskspace'] = processDiskspaceMetric
-    handlers['iostat'] = processDiskusageMetric
-    handlers['network'] = processNetworkMetric
-    handlers['default'] = processDefaultMetric
+    handlers = {'cpu': processCpuMetric, 'haproxy': processHaProxyMetric,
+                'mattermost': processMattermostMetric,
+                'diskspace': processDiskspaceMetric,
+                'iostat': processDiskusageMetric,
+                'network': processNetworkMetric,
+                'default': processDefaultMetric}
 
     def __init__(self, delegate, logger):
         self.path = delegate.path

--- a/src/diamond/utils/classes.py
+++ b/src/diamond/utils/classes.py
@@ -157,7 +157,7 @@ def load_collectors_from_paths(paths):
                 try:
                     # Import the module
                     mod = imp.load_module(modname, fp, pathname, description)
-                except (KeyboardInterrupt, SystemExit), err:
+                except (KeyboardInterrupt, SystemExit) as err:
                     logger.error(
                         "System or keyboard interrupt "
                         "while loading module %s"

--- a/src/diamond/utils/config.py
+++ b/src/diamond/utils/config.py
@@ -101,7 +101,7 @@ def load_config(configfile):
 
                 try:
                     newconfig = configobj.ConfigObj(cfgfile)
-                except Exception, e:
+                except Exception as e:
                     raise Exception("Failed to load config file %s due to %s" %
                                     (cfgfile, e))
 

--- a/src/diamond/utils/log.py
+++ b/src/diamond/utils/log.py
@@ -49,7 +49,7 @@ def setup_logging(configfile, stdout=False):
             streamHandler.setLevel(rootLogLevel)
             log.addHandler(streamHandler)
 
-    except Exception, e:
+    except Exception as e:
         sys.stderr.write("Error occurs when initialize logging: ")
         sys.stderr.write(str(e))
         sys.stderr.write(os.linesep)

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 ###############################################################################
 
+from __future__ import print_function
 import os
 import sys
 import inspect
@@ -105,7 +106,7 @@ class CollectorTestCase(unittest.TestCase):
         path = os.path.join(self.getFixtureDirPath(),
                             fixture_name)
         if not os.access(path, os.R_OK):
-            print "Missing Fixture " + path
+            print("Missing Fixture " + path)
         return path
 
     def getFixture(self, fixture_name):
@@ -240,8 +241,8 @@ def getCollectorTests(path):
                                                      locals(),
                                                      ['*'])
             except Exception:
-                print "Failed to import module: %s. %s" % (
-                    modname, traceback.format_exc())
+                print("Failed to import module: %s. %s" % (
+                    modname, traceback.format_exc()))
                 continue
 
     for f in os.listdir(path):

--- a/test.py
+++ b/test.py
@@ -9,12 +9,7 @@ import traceback
 import optparse
 import logging
 import configobj
-
-try:
-    # python 2.6
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 try:
     import cPickle as pickle


### PR DESCRIPTION
Python 2.6 is EOL and no longer receiving security updates, and is little used.

Here's the pip installs for Diamond from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  98.43% |         21,433 |
| 2.6            |   1.41% |            306 |
| 3.6            |   0.11% |             24 |
| 3.5            |   0.03% |              6 |
| 3.4            |   0.03% |              6 |

Source: `pypinfo --start-date -42 --end-date -15 --percent --pip --markdown Diamond pyversion`


This also:

* updates the code for newer Python 2.7+ features, 
* fixes some code inspections, 
* and includes some preparation towards Python 3 compatibility (https://github.com/python-diamond/Diamond/issues/396).