### PR TITLE
Makefile: debuild --no-tgz-check to prevent debuild from asking questions when localversion is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ builddeb: version
 	./setup.py sdist --prune
 	mkdir -p build
 	tar -C build -zxf dist/$(PROJECT)-$(VERSION).tar.gz
-	(cd build/$(PROJECT)-$(VERSION) && debuild -us -uc -v$(VERSION))
+	(cd build/$(PROJECT)-$(VERSION) && debuild --no-tgz-check -us -uc -v$(VERSION))
 	@echo "Package is at build/$(PROJECT)_$(VERSION)_all.deb"
 
 buildsourcedeb: version


### PR DESCRIPTION
`make builddeb` when `localversion` file is present (and package revision is set) complains that "This package has a Debian revision number but there does not seem to be an appropriate original tar file or .orig directory in the parent directory" and asks whether to proceed, which breaks unattended builds. This flag for `debuild` skips check for `orig` tarball.