### PR TITLE
Correct link to documentation

### DIFF
--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -4,7 +4,7 @@
 The CephCollector collects utilization info from the Ceph storage system.
 
 Documentation for ceph perf counters:
-http://ceph.com/docs/master/dev/perf_counters/
+http://docs.ceph.com/docs/master/dev/perf_counters/
 
 #### Dependencies
 


### PR DESCRIPTION
Simple link correction for Ceph Perf counters.
Old link doesn't provide right page