### PR TITLE
relax regular expression matching expection on mdstat._parse_array_me…

### DIFF
--- a/src/collectors/mdstat/mdstat.py
+++ b/src/collectors/mdstat/mdstat.py
@@ -204,7 +204,10 @@ class MdStatCollector(diamond.collector.Collector):
             'spare': 0
         }
         for member in members:
-            member_dict = device_regexp.match(member).groupdict()
+            match = device_regexp.match(member)
+            if not match:
+                continue
+            member_dict = match.groupdict()
 
             if member_dict['member_state'] == 'S':
                 ret['spare'] += 1


### PR DESCRIPTION
fixes issue #739.

```python

In [1]: from mdstat import MdStatCollector

In [2]: import re

In [3]: md = MdStatCollector()

In [4]: md._parse_mdstat()
sda5[0]
sdc5[1]
raid1
sda2[0]
sdc2[1]
Out[4]:
{'md1': {'member_count': {'active': 2, 'faulty': 0, 'spare': 0},
  'status': {'actual_members': 2,
   'blocks': 3904448,
   'superblock_version': 1.2,
   'total_members': 2}},
 'md2': {'bitmap': {'allocated_pages': '2',
   'chunk_size': '65536',
   'page_size': '8',
   'total_pages': '2'},
  'member_count': {'active': 2, 'faulty': 0, 'spare': 0},
  'status': {'actual_members': 2,
   'blocks': 239124288,
   'superblock_version': 1.2,
   'total_members': 2}}}

In [5]:

In [5]: !cat /proc/mdstat
Personalities : [raid1] [linear] [multipath] [raid0] [raid6] [raid5] [raid4] [raid10]
md2 : active raid1 sda5[0] sdc5[1]
      239124288 blocks super 1.2 [2/2] [UU]
      bitmap: 2/2 pages [8KB], 65536KB chunk

md1 : active (auto-read-only) raid1 sda2[0] sdc2[1]
      3904448 blocks super 1.2 [2/2] [UU]

md0 : active raid1 sda1[0] sdc1[1]
      975296 blocks super 1.2 [2/2] [UU]

unused devices: <none>

```