### PR TITLE
docs: fix simple typo, deploments -> deployments

### DIFF
--- a/docs/collectors/LibvirtKVMCollector.md
+++ b/docs/collectors/LibvirtKVMCollector.md
@@ -23,7 +23,7 @@ measure_collector_time | False | Collect the collector run time in ms | bool
 metrics_blacklist | None | Regex to match metrics to block. Mutually exclusive with metrics_whitelist | NoneType
 metrics_whitelist | None | Regex to match metrics to transmit. Mutually exclusive with metrics_blacklist | NoneType
 sort_by_uuid | False | Use the <uuid> of the instance instead of the<br>
- default <name>, useful in Openstack deploments where <name> is only<br>
+ default <name>, useful in Openstack deployments where <name> is only<br>
 specific to the compute node | bool
 uri | qemu:///system | The libvirt connection URI. By default it's<br>
 'qemu:///system'. One decent option is<br>

--- a/src/collectors/libvirtkvm/libvirtkvm.py
+++ b/src/collectors/libvirtkvm/libvirtkvm.py
@@ -49,7 +49,7 @@ class LibvirtKVMCollector(diamond.collector.Collector):
 'qemu:///system'. One decent option is
 'qemu+unix:///system?socket=/var/run/libvirt/libvit-sock-ro'.""",
             'sort_by_uuid': """Use the <uuid> of the instance instead of the
- default <name>, useful in Openstack deploments where <name> is only
+ default <name>, useful in Openstack deployments where <name> is only
 specific to the compute node""",
             'cpu_absolute': """CPU stats reported as percentage by default, or
 as cummulative nanoseconds since VM creation if this is True."""


### PR DESCRIPTION
There is a small typo in docs/collectors/LibvirtKVMCollector.md.

Should read `deployments` rather than `deploments`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md