### PR TITLE
Fix for issue introduced in #698

### DIFF
--- a/src/collectors/ntpd/ntpd.py
+++ b/src/collectors/ntpd/ntpd.py
@@ -76,7 +76,7 @@ class NtpdCollector(diamond.collector.Collector):
             data['poll'] = {'val': parts[5], 'precision': 0}
             data['reach'] = {'val': parts[6], 'precision': 0}
             data['delay'] = {'val': parts[7], 'precision': 6}
-            data['offset'] = {'val': parts[7], 'precision': 0}
+            data['offset'] = {'val': parts[8], 'precision': 0}
             data['jitter'] = {'val': parts[9], 'precision': 6}
 
         def convert_to_second(when_ntpd_ouput):

--- a/src/diamond/utils/scheduler.py
+++ b/src/diamond/utils/scheduler.py
@@ -52,7 +52,7 @@ def collector_process(collector, metric_queue, log):
     # avoid having all collectors running at the same time
     next_window = math.floor(time.time() / interval) * interval
 
-    if str_to_bool(self.config['stagger_collection']):
+    if str_to_bool(collector.config['stagger_collection']):
         stagger_offset = random.uniform(0, interval - 1)
 
     # Allocate time till the end of the window for the collector to run. With a


### PR DESCRIPTION
This patch should fix the error introduced with the merge of PR698:

Process MemoryCollector:
Traceback (most recent call last):
File "/usr/lib/python2.7/multiprocessing/process.py", line 267, in _bootstrap
self.run()
File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
self._target(*self._args, **self._kwargs)
File "/home/petem/git/Diamond/src/diamond/utils/scheduler.py", line 55, in collector_process
if str_to_bool(self.config['stagger_collection']):
NameError: global name 'self' is not defined