### PR TITLE
fix counter metric spike using statsD handler

### DIFF
--- a/src/diamond/handler/stats_d.py
+++ b/src/diamond/handler/stats_d.py
@@ -132,6 +132,9 @@ class StatsdHandler(Handler):
                 value = metric.raw_value
                 if metric.path in self.old_values:
                     value = value - self.old_values[metric.path]
+                # provide an option for caller to manually set the value
+                elif metric.value:
+                    value = metric.value
                 self.old_values[metric.path] = metric.raw_value
 
                 if hasattr(statsd, 'StatsClient'):


### PR DESCRIPTION
* Current implementation in statsD handler may work fine for general use case where the counter metric is sent from application directly to statsD (push), but in our prod env we have another stats application which pulls metrics from multiple applications and send to statsD, similar to how Promethus works (pull), and thus it will cause spike in the first data point every time when this stats application starts because the difference calculated automatically will be wrong if the actual application is already running for long time
* The fix is to adding an option for the caller to manually override the counter value using the value attribute but the internal update to the old value map will still use the raw value attribute